### PR TITLE
StackStorm Community HA

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   # Run Helm Lint checks
   helm-lint:
-    working_directory: ~/stackstorm-enterprise-ha
+    working_directory: ~/stackstorm-ha
     docker:
       - image: lachlanevenson/k8s-helm
     steps:
@@ -27,7 +27,7 @@ jobs:
             helm template --output-dir community .
             helm template --output-dir enterprise --set enterprise.enabled=true --set enterprise.license=123asd456fake .
       - persist_to_workspace:
-          root: ~/stackstorm-enterprise-ha/
+          root: ~/stackstorm-ha/
           paths:
             - community
             - enterprise
@@ -46,11 +46,11 @@ jobs:
       - run:
           name: K8s Kubeval Lint Check (Community)
           command: kubeval $(find . -type f)
-          working_directory: community/stackstorm-enterprise-ha/templates/
+          working_directory: community/stackstorm-ha/templates/
       - run:
           name: K8s Kubeval Lint Check (Enterprise)
           command: kubeval $(find . -type f)
-          working_directory: enterprise/stackstorm-enterprise-ha/templates/
+          working_directory: enterprise/stackstorm-ha/templates/
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,10 +16,10 @@ jobs:
             helm dependency update
       - run:
           name: Helm Lint Check
-          command: helm lint --set secrets.st2.license="123asd456fake"
+          command: helm lint --set enterprise.license="123asd456fake"
       - run:
           name: Helm template
-          command: helm template --output-dir . --set secrets.st2.license="123asd456fake" .
+          command: helm template --output-dir . --set enterprise.license="123asd456fake" .
       - persist_to_workspace:
           root: ~/stackstorm-enterprise-ha/stackstorm-enterprise-ha
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,15 +15,22 @@ jobs:
             helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
             helm dependency update
       - run:
-          name: Helm Lint Check
-          command: helm lint --set enterprise.license="123asd456fake"
+          name: Helm Lint Check (Community)
+          command: helm lint
+      - run:
+          name: Helm Lint Check (Enterprise)
+          command: helm lint --set enterprise.enabled=true --set enterprise.license=123asd456fake
       - run:
           name: Helm template
-          command: helm template --output-dir . --set enterprise.license="123asd456fake" .
+          command: |
+            mkdir -p enterprise community
+            helm template --output-dir community .
+            helm template --output-dir enterprise --set enterprise.enabled=true --set enterprise.license=123asd456fake .
       - persist_to_workspace:
-          root: ~/stackstorm-enterprise-ha/stackstorm-enterprise-ha
+          root: ~/stackstorm-enterprise-ha/
           paths:
-            - templates
+            - community
+            - enterprise
             # TODO: Fill an issue in https://github.com/garethr/kubeval
             # 'charts' contains 3rd party templates which doesn't validate against schema due to minor 'object != null' API validation issues
             # See: https://circleci.com/gh/StackStorm/stackstorm-enterprise-ha/18
@@ -37,8 +44,13 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: K8s Kubeval Lint Check
+          name: K8s Kubeval Lint Check (Community)
           command: kubeval $(find . -type f)
+          working_directory: community/stackstorm-enterprise-ha/templates/
+      - run:
+          name: K8s Kubeval Lint Check (Enterprise)
+          command: kubeval $(find . -type f)
+          working_directory: enterprise/stackstorm-enterprise-ha/templates/
 
 workflows:
   version: 2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## In Development
 
 
+## v0.6.0
+* Add StackStorm FOSS (community version), make Enterprise install optional (#22)
+* Rename chart `stackstorm-enterprise-ha` -> `stackstorm-ha` (#26)
+
 ## v0.5.1
 *  Move some of the defaults into original st2.conf
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm Enterprise version here to rely on other Docker images tags
 appVersion: 2.9dev
 name: stackstorm-enterprise-ha
-version: 0.5.2
+version: 0.6.0
 description: StackStorm Enterprise K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,7 @@
 apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 2.9dev
-# TODO: Rename to 'stackstorm-ha'
-name: stackstorm-enterprise-ha
+name: stackstorm-ha
 version: 0.6.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
@@ -16,7 +15,7 @@ keywords:
   - event-driven
   - auto-remediation
   - IFTTT
-  - ha
+  - HA
 maintainers:
   - name: Eugen C.
     url: https://github.com/armab
@@ -24,4 +23,5 @@ maintainers:
     url: https://github.com/warrenvw
 details:
   This Helm chart is a fully installable app that codifies StackStorm cluster optimized for HA and K8s environment.
+  By default FOSS community version of st2 will be installed. Enterprise version can be enabled as an option.
   For configuration details check 'values.yaml'.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,8 @@
 apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 2.9dev
-name: stackstorm-ha
+# TODO: Rename to 'stackstorm-ha'
+name: stackstorm-enterprise-ha
 version: 0.6.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
-appVersion: 2.9dev
+appVersion: 3.0dev
 name: stackstorm-ha
 version: 0.6.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,13 +1,13 @@
 apiVersion: v1
-# Update StackStorm Enterprise version here to rely on other Docker images tags
+# Update StackStorm version here to rely on other Docker images tags
 appVersion: 2.9dev
-name: stackstorm-enterprise-ha
+name: stackstorm-ha
 version: 0.6.0
-description: StackStorm Enterprise K8s Helm Chart, optimized for running StackStorm in HA environment.
+description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009
 source:
-  - https://github.com/stackstorm/k8s-st2
+  - https://github.com/stackstorm/stackstorm-ha
 keywords:
   - st2
   - stackstorm
@@ -22,6 +22,5 @@ maintainers:
   - name: Warren Van Winckel
     url: https://github.com/warrenvw
 details:
-  This Helm chart is a fully installable app that codifies StackStorm Enterprise optimized for HA and K8s environment.
-  You'll need to obtain StackStorm Enterprise license to install this chart. The 90-day trial can be requested at (https://stackstorm.com/#product).
+  This Helm chart is a fully installable app that codifies StackStorm cluster optimized for HA and K8s environment.
   For configuration details check 'values.yaml'.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stackstorm-ha` Helm Chart
 [![Build Status](https://circleci.com/gh/StackStorm/stackstorm-ha/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/stackstorm-ha) 
 
-K8s Helm Chart for running StackStorm cluster in HA mode.
+K8s Helm Chart for running StackStorm cluster in HA mode. 
 
 It will install 2 replicas for each component of StackStorm microservices for redundancy, as well as backends like
 RabbitMQ HA, MongoDB HA Replicaset and etcd cluster that st2 replies on for MQ, DB and distributed coordination respectively.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# `stackstorm-enterprise-ha` Helm Chart
-[![Build Status](https://circleci.com/gh/StackStorm/stackstorm-enterprise-ha/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/stackstorm-enterprise-ha) 
+# `stackstorm-ha` Helm Chart
+[![Build Status](https://circleci.com/gh/StackStorm/stackstorm-ha/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/stackstorm-ha) 
 
-StackStorm Enterprise K8s Helm Chart for running StackStorm Enterprise cluster in HA mode.
+K8s Helm Chart for running StackStorm cluster in HA mode.
 
 It will install 2 replicas for each component of StackStorm microservices for redundancy, as well as backends like
 RabbitMQ HA, MongoDB HA Replicaset and etcd cluster that st2 replies on for MQ, DB and distributed coordination respectively.
@@ -13,7 +13,7 @@ It's more than welcome to fine-tune each component settings to fit specific avai
 * [Helm](https://docs.helm.sh/using_helm/#install-helm) and [Tiller](https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller)
 
 ## Usage
-1) Edit `values.yaml` with configuration for the StackStorm Enterprise HA K8s cluster.
+1) Edit `values.yaml` with configuration for the StackStorm HA K8s cluster.
 > NB! It's highly recommended to set your own secrets as file contains unsafe defaults like self-signed SSL certificates, SSH keys,
 > StackStorm access and DB/MQ passwords!
 
@@ -24,11 +24,8 @@ helm dependency update
 
 3) Install the chart:
 ```
-helm install --set enterprise.license=<ST2_LICENSE_KEY> .
+helm install .
 ```
-
-> Don't have StackStorm Enterprise License?<br>
-> 90-day free trial can be requested at https://stackstorm.com/#product
 
 4) Upgrade.
 Once you make any changes to values, upgrade the cluster:
@@ -36,13 +33,24 @@ Once you make any changes to values, upgrade the cluster:
 helm upgrade <release-name> .
 ```
 
+### $ Enterprise (Optional)
+By default, StackStorm Community FOSS version is configured via Helm chart. If you want to install [StackStorm Enterprise (EWC)](https://docs.stackstorm.com/install/ewc_ha.html), run:
+```
+helm install --set enterprise.enabled=true --set enterprise.license=<ST2_LICENSE_KEY> .
+```
+It will pull enterprise images from private Docker registry as well as allows configuring features like RBAC and LDAP.
+See Helm `values.yaml`, `enterprise` section for configuration examples.
+
+> Don't have StackStorm Enterprise License?<br>
+> 90-day free trial can be requested at https://stackstorm.com/#product
+
 ## Components
 ### st2client
-A helper container to switch into and run st2 CLI commands against the deployed StackStorm Enterprise cluster.
+A helper container to switch into and run st2 CLI commands against the deployed StackStorm cluster.
 All resources like credentials, configs, RBAC, packs, keys and secrets are shared with this container.
 ```
 # obtain st2client pod name
-ST2CLIENT=$(kubectl get pod -l app=st2client,support=enterprise -o jsonpath="{.items[0].metadata.name}")
+ST2CLIENT=$(kubectl get pod -l app=st2client -o jsonpath="{.items[0].metadata.name}")
 
 # run a single st2 client command
 kubectl exec -it ${ST2CLIENT} -- st2 --version
@@ -172,7 +180,7 @@ docker push ${DOCKER_REGISTRY}/st2packs:latest
 ```
 
 ### How to provide custom pack configs
-Update the `pack.configs` section of `stackstorm-enterprise-ha/values.yaml`:
+Update the `pack.configs` section of `stackstorm-ha/values.yaml`:
 
 For example:
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # `stackstorm-ha` Helm Chart
-[![Build Status](https://circleci.com/gh/StackStorm/stackstorm-ha/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/stackstorm-ha) 
+[![Build Status](https://circleci.com/gh/StackStorm/stackstorm-ha/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/stackstorm-ha)
 
-K8s Helm Chart for running StackStorm cluster in HA mode. 
+K8s Helm Chart for running StackStorm cluster in HA mode.
 
 It will install 2 replicas for each component of StackStorm microservices for redundancy, as well as backends like
 RabbitMQ HA, MongoDB HA Replicaset and etcd cluster that st2 replies on for MQ, DB and distributed coordination respectively.

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Once you make any changes to values, upgrade the cluster:
 helm upgrade <release-name> .
 ```
 
-### $ Enterprise (Optional)
+### Enterprise (Optional)
 By default, StackStorm Community FOSS version is configured via Helm chart. If you want to install [StackStorm Enterprise (EWC)](https://docs.stackstorm.com/install/ewc_ha.html), run:
 ```
 helm install --set enterprise.enabled=true --set enterprise.license=<ST2_LICENSE_KEY> .

--- a/README.md
+++ b/README.md
@@ -22,12 +22,12 @@ It's more than welcome to fine-tune each component settings to fit specific avai
 helm dependency update
 ```
 
-3) Install the chart:
+3) Install the chart
 ```
 helm install .
 ```
 
-4) Upgrade.
+4) Upgrade
 Once you make any changes to values, upgrade the cluster:
 ```
 helm upgrade <release-name> .

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ helm dependency update
 
 3) Install the chart:
 ```
-helm install --set secrets.st2.license=<ST2_LICENSE_KEY> .
+helm install --set enterprise.license=<ST2_LICENSE_KEY> .
 ```
 
 > Don't have StackStorm Enterprise License?<br>

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -9,7 +9,7 @@ Congratulations! You have just deployed StackStorm {{ if .Values.enterprise.enab
 
 1. Get the StackStorm Web UI URL by running these commands:
 export ST2WEB_IP=$(minikube ip 2>/dev/null || kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-export ST2WEB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ .Release.Name }}-st2web{{ if .Values.enterprise.enabled }}-enterprise{{ end }})
+export ST2WEB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }})
 echo https://${ST2WEB_IP}:${ST2WEB_PORT}/
 
 2. Login with the following credentials:

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -1,4 +1,4 @@
-Congratulations! You have just deployed StackStorm Enterprise HA!
+Congratulations! You have just deployed StackStorm {{ if .Values.enterprise.enabled }}Enterprise {{ end }}HA!
 
   ███████╗████████╗██████╗     ██╗  ██╗ █████╗      ██████╗ ██╗  ██╗
   ██╔════╝╚══██╔══╝╚════██╗    ██║  ██║██╔══██╗    ██╔═══██╗██║ ██╔╝
@@ -9,7 +9,7 @@ Congratulations! You have just deployed StackStorm Enterprise HA!
 
 1. Get the StackStorm Web UI URL by running these commands:
 export ST2WEB_IP=$(minikube ip 2>/dev/null || kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-export ST2WEB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ .Release.Name }}-st2web-enterprise)
+export ST2WEB_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ .Release.Name }}-st2web{{ if .Values.enterprise.enabled }}-enterprise{{ end }})
 echo https://${ST2WEB_IP}:${ST2WEB_PORT}/
 
 2. Login with the following credentials:
@@ -22,4 +22,8 @@ kubectl exec -it ${ST2CLIENT} -- st2 --version
 
 -----------------------------------------------------
 Thanks for trying StackStorm!
+{{- if .Values.enterprise.enabled }}
 Need help? Enterprise support: support@stackstorm.com
+{{- else }}
+Enterprise: https://stackstorm.com/#product
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -6,7 +6,7 @@
 {{- end }}
 
 # Generate support method used in labels. This is based on community/enterprise
-{{- define "supportMethod" }}
+{{- define "supportMethod" -}}
 {{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
 enterprise
 {{- else -}}
@@ -15,10 +15,15 @@ community
 {{- end }}
 
 # Generate Docker image repository: Private 'docker.stackstorm.com' for Enterprise vs Public Docker Hub 'stackstorm' for FOSS version
-{{- define "imageRepository" }}
+{{- define "imageRepository" -}}
 {{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
 docker.stackstorm.com
 {{- else -}}
 stackstorm
 {{- end -}}
+{{- end -}}
+
+# Generate '-enterprise' suffix only when it's needed for resource names, docker images, etc
+{{- define "enterpriseSuffix" -}}
+{{ if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled }}-enterprise{{ end }}
 {{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,6 +1,6 @@
 {{- define "imagePullSecret" }}
 {{- if .Values.enterprise.enabled -}}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.repository (printf "%s:%s" .Values.enterprise.license .Values.enterprise.license | b64enc) | b64enc }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" "docker.stackstorm.com" (printf "%s:%s" .Values.enterprise.license .Values.enterprise.license | b64enc) | b64enc }}
 {{- end -}}
 {{- end }}
 
@@ -11,3 +11,11 @@ enterprise
 community
 {{- end -}}
 {{- end }}
+
+{{- define "imageRepository" }}
+{{- if .Values.enterprise.enabled -}}
+docker.stackstorm.com
+{{- else -}}
+stackstorm
+{{- end -}}
+{{- end -}}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,3 +1,3 @@
 {{- define "imagePullSecret" }}
-{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.repository (printf "%s:%s" .Values.secrets.st2.license .Values.secrets.st2.license | b64enc) | b64enc }}
+{{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.repository (printf "%s:%s" .Values.enterprise.license .Values.enterprise.license | b64enc) | b64enc }}
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,9 +1,11 @@
+# Image pull secret used to access private docker.stackstorm.com Docker registry with Enterprise images
 {{- define "imagePullSecret" }}
 {{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" "docker.stackstorm.com" (printf "%s:%s" .Values.enterprise.license .Values.enterprise.license | b64enc) | b64enc }}
 {{- end -}}
 {{- end }}
 
+# Generate support method used in labels. This is based on community/enterprise
 {{- define "supportMethod" }}
 {{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
 enterprise
@@ -12,6 +14,7 @@ community
 {{- end -}}
 {{- end }}
 
+# Generate Docker image repository: Private 'docker.stackstorm.com' for Enterprise vs Public Docker Hub 'stackstorm' for FOSS version
 {{- define "imageRepository" }}
 {{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
 docker.stackstorm.com

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,3 +1,5 @@
 {{- define "imagePullSecret" }}
+{{- if .Values.enterprise.enabled -}}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.repository (printf "%s:%s" .Values.enterprise.license .Values.enterprise.license | b64enc) | b64enc }}
+{{- end -}}
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -3,3 +3,11 @@
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" .Values.image.repository (printf "%s:%s" .Values.enterprise.license .Values.enterprise.license | b64enc) | b64enc }}
 {{- end -}}
 {{- end }}
+
+{{- define "supportMethod" }}
+{{- if .Values.enterprise.enabled -}}
+enterprise
+{{- else -}}
+community
+{{- end -}}
+{{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,11 +1,11 @@
 {{- define "imagePullSecret" }}
-{{- if .Values.enterprise.enabled -}}
+{{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
 {{- printf "{\"auths\": {\"%s\": {\"auth\": \"%s\"}}}" "docker.stackstorm.com" (printf "%s:%s" .Values.enterprise.license .Values.enterprise.license | b64enc) | b64enc }}
 {{- end -}}
 {{- end }}
 
 {{- define "supportMethod" }}
-{{- if .Values.enterprise.enabled -}}
+{{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
 enterprise
 {{- else -}}
 community
@@ -13,7 +13,7 @@ community
 {{- end }}
 
 {{- define "imageRepository" }}
-{{- if .Values.enterprise.enabled -}}
+{{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
 docker.stackstorm.com
 {{- else -}}
 stackstorm

--- a/templates/configmaps_packs.yaml
+++ b/templates/configmaps_packs.yaml
@@ -9,7 +9,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/templates/configmaps_rbac.yaml
+++ b/templates/configmaps_rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: {{ template "supportMethod" . }}
+    support: enterprise
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +28,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: {{ template "supportMethod" . }}
+    support: enterprise
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -46,7 +46,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: {{ template "supportMethod" . }}
+    support: enterprise
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/templates/configmaps_rbac.yaml
+++ b/templates/configmaps_rbac.yaml
@@ -10,7 +10,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -28,7 +28,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -46,7 +46,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/templates/configmaps_rbac.yaml
+++ b/templates/configmaps_rbac.yaml
@@ -14,7 +14,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{ toYaml .Values.st2.rbac.roles | indent 2 }}
+{{ toYaml .Values.enterprise.rbac.roles | indent 2 }}
 
 ---
 apiVersion: v1
@@ -32,7 +32,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{ toYaml .Values.st2.rbac.assignments | indent 2 }}
+{{ toYaml .Values.enterprise.rbac.assignments | indent 2 }}
 
 ---
 apiVersion: v1
@@ -50,8 +50,8 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{- if .Values.st2.rbac.mappings }}
-{{ toYaml .Values.st2.rbac.mappings | indent 2 }}
+{{- if .Values.enterprise.rbac.mappings }}
+{{ toYaml .Values.enterprise.rbac.mappings | indent 2 }}
 {{ else }}
   {}
 {{ end }}

--- a/templates/configmaps_rbac.yaml
+++ b/templates/configmaps_rbac.yaml
@@ -1,3 +1,4 @@
+{{ if .Values.enterprise.enabled }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -54,4 +55,5 @@ data:
 {{ toYaml .Values.enterprise.rbac.mappings | indent 2 }}
 {{ else }}
   {}
+{{ end }}
 {{ end }}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -19,7 +19,7 @@ data:
   # The order of merging: st2.conf < st2.docker.conf < st2.user.conf
   st2.docker.conf: |
     [auth]
-    api_url = http://{{ .Release.Name }}-st2api-enterprise:9101/
+    api_url = http://{{ .Release.Name }}-st2api{{ template "enterpriseSuffix" . }}:9101/
     [coordination]
     url = etcd://{{ .Release.Name }}-etcd:2379
     [messaging]

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -9,7 +9,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/templates/configmaps_st2-urls.yaml
+++ b/templates/configmaps_st2-urls.yaml
@@ -9,7 +9,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}

--- a/templates/configmaps_st2-urls.yaml
+++ b/templates/configmaps_st2-urls.yaml
@@ -14,6 +14,6 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-  ST2_AUTH_URL: http://{{ .Release.Name }}-st2auth-enterprise:9100/
-  ST2_API_URL: http://{{ .Release.Name }}-st2api-enterprise:9101/
-  ST2_STREAM_URL: http://{{ .Release.Name }}-st2stream-enterprise:9102/
+  ST2_AUTH_URL: http://{{ .Release.Name }}-st2auth{{ template "enterpriseSuffix" . }}:9100/
+  ST2_API_URL: http://{{ .Release.Name }}-st2api{{ template "enterpriseSuffix" . }}:9101/
+  ST2_STREAM_URL: http://{{ .Release.Name }}-st2stream{{ template "enterpriseSuffix" . }}:9102/

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -41,7 +41,7 @@ spec:
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       initContainers:
       - name: generate-htpasswd
-        image: "{{ .Values.image.repository }}/st2auth-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2auth-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: ST2_AUTH_USERNAME
@@ -63,7 +63,7 @@ spec:
           - printf "${ST2_AUTH_USERNAME}:$(openssl passwd -apr1 "${ST2_AUTH_PASSWORD}")\n" > /tmp/st2/htpasswd
       containers:
       - name: st2auth-enterprise
-        image: "{{ .Values.image.repository }}/st2auth-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2auth-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9100
@@ -165,7 +165,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -181,7 +181,7 @@ spec:
       {{- end }}
       containers:
       - name: st2api-enterprise
-        image: "{{ .Values.image.repository }}/st2api-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2api-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9101
@@ -272,7 +272,7 @@ spec:
       {{- end }}
       containers:
       - name: st2stream-enterprise
-        image: "{{ .Values.image.repository }}/st2stream-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2stream-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9102
@@ -345,7 +345,7 @@ spec:
       {{- end }}
       containers:
       - name: st2web-enterprise
-        image: "{{ .Values.image.repository }}/st2web-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2web-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 443
@@ -444,7 +444,7 @@ spec:
       {{- end }}
       containers:
       - name: st2rulesengine-enterprise
-        image: "{{ .Values.image.repository }}/st2rulesengine-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2rulesengine-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -520,7 +520,7 @@ spec:
       {{- end }}
       containers:
       - name: st2timersengine-enterprise
-        image: "{{ .Values.image.repository }}/st2timersengine-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2timersengine-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -595,7 +595,7 @@ spec:
       {{- end }}
       containers:
       - name: st2workflowengine-enterprise
-        image: "{{ .Values.image.repository }}/st2workflowengine-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2workflowengine-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -670,7 +670,7 @@ spec:
       {{- end }}
       containers:
       - name: st2notifier-enterprise
-        image: "{{ .Values.image.repository }}/st2notifier-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2notifier-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -766,7 +766,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -780,7 +780,7 @@ spec:
       {{- end }}
       containers:
       - name: st2sensorcontainer-enterprise
-        image: "{{ .Values.image.repository }}/st2sensorcontainer-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2sensorcontainer-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -889,7 +889,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -903,7 +903,7 @@ spec:
       {{- end }}
       containers:
       - name: st2actionrunner-enterprise
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -1003,7 +1003,7 @@ spec:
       {{- end }}
       containers:
       - name: st2garbagecollector-enterprise
-        image: "{{ .Values.image.repository }}/st2garbagecollector-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2garbagecollector-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -1100,7 +1100,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -1114,7 +1114,7 @@ spec:
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
         - configMapRef:
@@ -1145,7 +1145,7 @@ spec:
             EOT
       containers:
       - name: st2client-enterprise
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: ST2CLIENT

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2auth-enterprise
+  name: {{ .Release.Name }}-st2auth{{ template "enterpriseSuffix" . }}
   labels:
     app: st2auth
     tier: backend
@@ -41,7 +41,7 @@ spec:
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       initContainers:
       - name: generate-htpasswd
-        image: "{{ template "imageRepository" . }}/st2auth-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2auth{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: ST2_AUTH_USERNAME
@@ -62,8 +62,8 @@ spec:
           - '-ec'
           - printf "${ST2_AUTH_USERNAME}:$(openssl passwd -apr1 "${ST2_AUTH_PASSWORD}")\n" > /tmp/st2/htpasswd
       containers:
-      - name: st2auth-enterprise
-        image: "{{ template "imageRepository" . }}/st2auth-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2auth{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2auth{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9100
@@ -110,7 +110,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2api-enterprise
+  name: {{ .Release.Name }}-st2api{{ template "enterpriseSuffix" . }}
   labels:
     app: st2api
     tier: backend
@@ -147,7 +147,7 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
-      # Merge packs and virtualenvs from st2api-enterprise with those from the st2.packs image
+      # Merge packs and virtualenvs from st2api with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
         image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
@@ -165,7 +165,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -180,8 +180,8 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       {{- end }}
       containers:
-      - name: st2api-enterprise
-        image: "{{ template "imageRepository" . }}/st2api-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2api{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2api{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9101
@@ -235,7 +235,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2stream-enterprise
+  name: {{ .Release.Name }}-st2stream{{ template "enterpriseSuffix" . }}
   labels:
     app: st2stream
     tier: backend
@@ -271,8 +271,8 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
       containers:
-      - name: st2stream-enterprise
-        image: "{{ template "imageRepository" . }}/st2stream-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2stream{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2stream{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9102
@@ -312,7 +312,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2web-enterprise
+  name: {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }}
   labels:
     app: st2web
     tier: frontend
@@ -344,8 +344,8 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
       containers:
-      - name: st2web-enterprise
-        image: "{{ template "imageRepository" . }}/st2web-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2web{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2web{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 443
@@ -407,7 +407,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2rulesengine-enterprise
+  name: {{ .Release.Name }}-st2rulesengine{{ template "enterpriseSuffix" . }}
   labels:
     app: st2rulesengine
     tier: backend
@@ -443,8 +443,8 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
       containers:
-      - name: st2rulesengine-enterprise
-        image: "{{ template "imageRepository" . }}/st2rulesengine-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2rulesengine{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2rulesengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -482,7 +482,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2timersengine-enterprise
+  name: {{ .Release.Name }}-st2timersengine{{ template "enterpriseSuffix" . }}
   labels:
     app: st2timersengine
     tier: backend
@@ -519,8 +519,8 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
       containers:
-      - name: st2timersengine-enterprise
-        image: "{{ template "imageRepository" . }}/st2timersengine-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2timersengine{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2timersengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -558,7 +558,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2workflowengine-enterprise
+  name: {{ .Release.Name }}-st2workflowengine{{ template "enterpriseSuffix" . }}
   labels:
     app: st2workflowengine
     tier: backend
@@ -594,8 +594,8 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
       containers:
-      - name: st2workflowengine-enterprise
-        image: "{{ template "imageRepository" . }}/st2workflowengine-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2workflowengine{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2workflowengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -633,7 +633,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2notifier-enterprise
+  name: {{ .Release.Name }}-st2notifier{{ template "enterpriseSuffix" . }}
   labels:
     app: st2notifier
     tier: backend
@@ -669,8 +669,8 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
       containers:
-      - name: st2notifier-enterprise
-        image: "{{ template "imageRepository" . }}/st2notifier-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2notifier{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2notifier{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -708,7 +708,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2sensorcontainer-enterprise
+  name: {{ .Release.Name }}-st2sensorcontainer{{ template "enterpriseSuffix" . }}
   labels:
     app: st2sensorcontainer
     tier: backend
@@ -748,7 +748,7 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
-      # Merge packs and virtualenvs from st2sensorcontainer-enterprise with those from the st2.packs image
+      # Merge packs and virtualenvs from st2sensorcontainer with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
         image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
@@ -766,7 +766,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -779,8 +779,8 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       {{- end }}
       containers:
-      - name: st2sensorcontainer-enterprise
-        image: "{{ template "imageRepository" . }}/st2sensorcontainer-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2sensorcontainer{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2sensorcontainer{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -832,7 +832,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2actionrunner-enterprise
+  name: {{ .Release.Name }}-st2actionrunner{{ template "enterpriseSuffix" . }}
   labels:
     app: st2actionrunner
     tier: backend
@@ -871,7 +871,7 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
-      # Merge packs and virtualenvs from st2actionrunner-enterprise with those from the st2.packs image
+      # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
         image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
@@ -889,7 +889,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -902,8 +902,8 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       {{- end }}
       containers:
-      - name: st2actionrunner-enterprise
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2actionrunner{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -966,7 +966,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2garbagecollector-enterprise
+  name: {{ .Release.Name }}-st2garbagecollector{{ template "enterpriseSuffix" . }}
   labels:
     app: st2garbagecollector
     tier: backend
@@ -1002,8 +1002,8 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
       containers:
-      - name: st2garbagecollector-enterprise
-        image: "{{ template "imageRepository" . }}/st2garbagecollector-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2garbagecollector{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2garbagecollector{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -1041,7 +1041,7 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-st2client-enterprise
+  name: {{ .Release.Name }}-st2client{{ template "enterpriseSuffix" . }}
   labels:
     app: st2client
     tier: backend
@@ -1082,7 +1082,7 @@ spec:
       {{- end }}
       initContainers:
       {{- if .Values.st2.packs.image.repository }}
-      # Merge packs and virtualenvs from st2actionrunner-enterprise with those from the st2.packs image
+      # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
         image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
@@ -1100,7 +1100,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -1114,7 +1114,7 @@ spec:
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
         - configMapRef:
@@ -1144,8 +1144,8 @@ spec:
             password = ${ST2_AUTH_PASSWORD}
             EOT
       containers:
-      - name: st2client-enterprise
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+      - name: st2client{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: ST2CLIENT

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -7,7 +7,7 @@ metadata:
     app: st2auth
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -15,7 +15,7 @@ spec:
   selector:
     matchLabels:
       app: st2auth
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2auth
   # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
@@ -26,7 +26,7 @@ spec:
         app: st2auth
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -115,7 +115,7 @@ metadata:
     app: st2api
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -123,7 +123,7 @@ spec:
   selector:
     matchLabels:
       app: st2api
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2api
   # Multiple st2api process can be behind a load balancer in an active-active configuration.
@@ -134,7 +134,7 @@ spec:
         app: st2api
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -240,7 +240,7 @@ metadata:
     app: st2stream
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -248,7 +248,7 @@ spec:
   selector:
     matchLabels:
       app: st2stream
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2stream
   # Multiple st2stream process can be behind a load balancer in an active-active configuration.
@@ -259,7 +259,7 @@ spec:
         app: st2stream
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -317,7 +317,7 @@ metadata:
     app: st2web
     tier: frontend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -325,7 +325,7 @@ spec:
   selector:
     matchLabels:
       app: st2web
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   replicas: {{ default 2 .Values.st2web.replicas }}
   template:
@@ -334,7 +334,7 @@ spec:
         app: st2web
         tier: frontend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -412,7 +412,7 @@ metadata:
     app: st2rulesengine
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -420,7 +420,7 @@ spec:
   selector:
     matchLabels:
       app: st2rulesengine
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2rulesengine
   # Multiple st2rulesengine processes can run in active-active with only connections to MongoDB and RabbitMQ. All these will share the TriggerInstance load and naturally pick up more work if one or more of the processes becomes unavailable.
@@ -431,7 +431,7 @@ spec:
         app: st2rulesengine
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -487,7 +487,7 @@ metadata:
     app: st2timersengine
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -495,7 +495,7 @@ spec:
   selector:
     matchLabels:
       app: st2timersengine
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2timersengine
   # Only single replica is created as timersengine can't work in active-active mode at the moment and it relies on
@@ -507,7 +507,7 @@ spec:
         app: st2timersengine
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -563,7 +563,7 @@ metadata:
     app: st2workflowengine
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -571,7 +571,7 @@ spec:
   selector:
     matchLabels:
       app: st2workflowengine
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2workflowengine
   # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
@@ -582,7 +582,7 @@ spec:
         app: st2workflowengine
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -638,7 +638,7 @@ metadata:
     app: st2notifier
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -646,7 +646,7 @@ spec:
   selector:
     matchLabels:
       app: st2notifier
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2notifier
   # st2notifier runs in active-active mode and requires for that coordination backend like Redis or Zookeeper
@@ -657,7 +657,7 @@ spec:
         app: st2notifier
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -713,7 +713,7 @@ metadata:
     app: st2sensorcontainer
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -721,7 +721,7 @@ spec:
   selector:
     matchLabels:
       app: st2sensorcontainer
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
   # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance. Each sensor node needs to be
@@ -735,7 +735,7 @@ spec:
         app: st2sensorcontainer
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -837,7 +837,7 @@ metadata:
     app: st2actionrunner
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -845,7 +845,7 @@ spec:
   selector:
     matchLabels:
       app: st2actionrunner
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2actionrunner
   # Multiple st2actionrunner processes can run in active-active with only connections to MongoDB and RabbitMQ. Work gets naturally
@@ -857,7 +857,7 @@ spec:
         app: st2actionrunner
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -971,7 +971,7 @@ metadata:
     app: st2garbagecollector
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -979,7 +979,7 @@ spec:
   selector:
     matchLabels:
       app: st2garbagecollector
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
   # Having 1 st2garbagecollector unique replica is enough for periodic task like st2 history garbage collection
@@ -990,7 +990,7 @@ spec:
         app: st2garbagecollector
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -1046,7 +1046,7 @@ metadata:
     app: st2client
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -1054,7 +1054,7 @@ spec:
   selector:
     matchLabels:
       app: st2client
-      support: enterprise
+      support: {{ template "supportMethod" . }}
       release: {{ .Release.Name }}
   replicas: 1
   template:
@@ -1063,7 +1063,7 @@ spec:
         app: st2client
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -34,8 +34,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       initContainers:
       - name: generate-htpasswd
@@ -139,8 +141,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
       # Merge packs and virtualenvs from st2api-enterprise with those from the st2.packs image
@@ -262,8 +266,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       containers:
       - name: st2stream-enterprise
         image: "{{ .Values.image.repository }}/st2stream-enterprise:{{ .Chart.AppVersion }}"
@@ -333,8 +339,10 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       containers:
       - name: st2web-enterprise
         image: "{{ .Values.image.repository }}/st2web-enterprise:{{ .Chart.AppVersion }}"
@@ -430,8 +438,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       containers:
       - name: st2rulesengine-enterprise
         image: "{{ .Values.image.repository }}/st2rulesengine-enterprise:{{ .Chart.AppVersion }}"
@@ -504,8 +514,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       containers:
       - name: st2timersengine-enterprise
         image: "{{ .Values.image.repository }}/st2timersengine-enterprise:{{ .Chart.AppVersion }}"
@@ -577,8 +589,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       containers:
       - name: st2workflowengine-enterprise
         image: "{{ .Values.image.repository }}/st2workflowengine-enterprise:{{ .Chart.AppVersion }}"
@@ -650,8 +664,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       containers:
       - name: st2notifier-enterprise
         image: "{{ .Values.image.repository }}/st2notifier-enterprise:{{ .Chart.AppVersion }}"
@@ -726,8 +742,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
       # Merge packs and virtualenvs from st2sensorcontainer-enterprise with those from the st2.packs image
@@ -847,8 +865,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
       # Merge packs and virtualenvs from st2actionrunner-enterprise with those from the st2.packs image
@@ -977,8 +997,10 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       containers:
       - name: st2garbagecollector-enterprise
         image: "{{ .Values.image.repository }}/st2garbagecollector-enterprise:{{ .Chart.AppVersion }}"
@@ -1047,13 +1069,17 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if .Values.enterprise.enabled }}
         checksum/rbac: {{ include (print $.Template.BasePath "/configmaps_rbac.yaml") . | sha256sum }}
+        {{- end }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
       initContainers:
       {{- if .Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2actionrunner-enterprise with those from the st2.packs image
@@ -1134,12 +1160,14 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
+        {{- if .Values.enterprise.enabled }}
         - name: st2-rbac-roles-vol
           mountPath: /opt/stackstorm/rbac/roles/
         - name: st2-rbac-assignments-vol
           mountPath: /opt/stackstorm/rbac/assignments/
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
+        {{- end }}
         - name: st2-pack-configs-vol
           mountPath: /opt/stackstorm/configs/
         - name: st2client-config-vol
@@ -1167,6 +1195,7 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
+        {{- if .Values.enterprise.enabled }}
         - name: st2-rbac-roles-vol
           configMap:
             name: {{ .Release.Name }}-st2-rbac-roles
@@ -1176,6 +1205,7 @@ spec:
         - name: st2-rbac-mappings-vol
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
+        {{- end }}
         - name: st2-pack-configs-vol
           configMap:
             name: {{ .Release.Name }}-st2-pack-configs

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -38,7 +38,7 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
-      # Merge packs and virtualenvs from st2actionrunner-enterprise with those from the st2.packs image
+      # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
         image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
@@ -56,7 +56,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -70,7 +70,7 @@ spec:
       {{ end }}
       containers:
       - name: st2-register-content
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - st2-register-content
@@ -150,7 +150,7 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       containers:
       - name: st2-apply-rbac-definitions
-        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - st2-apply-rbac-definitions

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -32,9 +32,11 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
-      {{ if .Values.st2.packs.image.repository }}
+      {{- end }}
+      {{- if .Values.st2.packs.image.repository }}
       initContainers:
       # Merge packs and virtualenvs from st2actionrunner-enterprise with those from the st2.packs image
       # Custom packs
@@ -86,12 +88,12 @@ spec:
           subPath: st2.user.conf
         - name: st2-pack-configs-vol
           mountPath: /opt/stackstorm/configs/
-        {{ if .Values.st2.packs.image.repository }}
+        {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs/
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs/
-        {{ end }}
+        {{- end }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -101,14 +103,15 @@ spec:
         - name: st2-pack-configs-vol
           configMap:
             name: {{ .Release.Name }}-st2-pack-configs
-        {{ if .Values.st2.packs.image.repository }}
+        {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           emptyDir: {}
         - name: st2-virtualenvs-vol
           emptyDir: {}
-        {{ end }}
+        {{- end }}
       restartPolicy: OnFailure
 
+{{ if .Values.enterprise.enabled }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -184,3 +187,4 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
       restartPolicy: OnFailure
+{{ end }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -121,7 +121,7 @@ metadata:
     app: st2-apply-rbac-definitions
     tier: backend
     vendor: stackstorm
-    support: {{ template "supportMethod" . }}
+    support: enterprise
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -137,7 +137,7 @@ spec:
         app: st2-apply-rbac-definitions
         tier: backend
         vendor: stackstorm
-        support: {{ template "supportMethod" . }}
+        support: enterprise
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -7,7 +7,7 @@ metadata:
     app: st2-register-content
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -23,7 +23,7 @@ spec:
         app: st2-register-content
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
@@ -121,7 +121,7 @@ metadata:
     app: st2-apply-rbac-definitions
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
@@ -137,7 +137,7 @@ spec:
         app: st2-apply-rbac-definitions
         tier: backend
         vendor: stackstorm
-        support: enterprise
+        support: {{ template "supportMethod" . }}
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -56,7 +56,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       # System packs
       - name: st2-system-packs
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         volumeMounts:
         - name: st2-packs-vol
@@ -70,7 +70,7 @@ spec:
       {{ end }}
       containers:
       - name: st2-register-content
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - st2-register-content
@@ -150,7 +150,7 @@ spec:
       - name: {{ .Release.Name }}-st2-license
       containers:
       - name: st2-apply-rbac-definitions
-        image: "{{ .Values.image.repository }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
+        image: "{{ template "imageRepository" . }}/st2actionrunner-enterprise:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - st2-apply-rbac-definitions

--- a/templates/secrets_ssh.yaml
+++ b/templates/secrets_ssh.yaml
@@ -9,7 +9,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/templates/secrets_st2auth.yaml
+++ b/templates/secrets_st2auth.yaml
@@ -9,7 +9,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/templates/secrets_st2license.yaml
+++ b/templates/secrets_st2license.yaml
@@ -10,7 +10,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: {{ template "supportMethod" . }}
+    support: enterprise
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/templates/secrets_st2license.yaml
+++ b/templates/secrets_st2license.yaml
@@ -10,7 +10,7 @@ metadata:
     app: st2
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/templates/secrets_st2license.yaml
+++ b/templates/secrets_st2license.yaml
@@ -15,6 +15,6 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: kubernetes.io/dockerconfigjson
 data:
-  # Ensure that secret 'st2.license' is required and was really specified
-  st2_license: {{ required "Secret 'st2.license' is required to pull StackStorm Enterprise images! Don't have one? Obtain 90-day free trial at https://stackstorm.com/#product" .Values.secrets.st2.license }}
+  # Ensure that secret 'enterprise.license' is required and was really specified
+  st2_license: {{ required "Secret 'enterprise.license' is required to pull StackStorm Enterprise images! Don't have one? Obtain 90-day free trial at https://stackstorm.com/#product" .Values.enterprise.license }}
   .dockerconfigjson: {{ template "imagePullSecret" . }}

--- a/templates/secrets_st2license.yaml
+++ b/templates/secrets_st2license.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.enterprise.enabled }}
 ---
 apiVersion: v1
 kind: Secret
@@ -18,3 +19,4 @@ data:
   # Ensure that secret 'enterprise.license' is required and was really specified
   st2_license: {{ required "Secret 'enterprise.license' is required to pull StackStorm Enterprise images! Don't have one? Obtain 90-day free trial at https://stackstorm.com/#product" .Values.enterprise.license }}
   .dockerconfigjson: {{ template "imagePullSecret" . }}
+{{- end }}

--- a/templates/secrets_st2web.yaml
+++ b/templates/secrets_st2web.yaml
@@ -9,7 +9,7 @@ metadata:
     app: st2web
     tier: frontend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -2,7 +2,7 @@
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-st2auth-enterprise
+  name: {{ .Release.Name }}-st2auth{{ template "enterpriseSuffix" . }}
   annotations:
     description: StackStorm st2auth - all authentication is managed by this service.
   labels:
@@ -27,7 +27,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-st2api-enterprise
+  name: {{ .Release.Name }}-st2api{{ template "enterpriseSuffix" . }}
   annotations:
     description: StackStorm st2api - service hosts the REST API endpoints that serve requests from WebUI, CLI, ChatOps and other st2 services.
   labels:
@@ -52,7 +52,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-st2stream-enterprise
+  name: {{ .Release.Name }}-st2stream{{ template "enterpriseSuffix" . }}
   annotations:
     description: StackStorm st2stream - exposes a server-sent event stream, used by the clients like WebUI and ChatOps to receive update from the st2stream server.
   labels:
@@ -77,7 +77,7 @@ spec:
 kind: Service
 apiVersion: v1
 metadata:
-  name: {{ .Release.Name }}-st2web-enterprise
+  name: {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }}
   annotations:
     description: StackStorm st2web, - an admin Web UI and main entry point for external API requests
   labels:

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -9,14 +9,14 @@ metadata:
     app: st2auth
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
     app: st2auth
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     release: {{ .Release.Name }}
   type: ClusterIP
   ports:
@@ -34,14 +34,14 @@ metadata:
     app: st2api
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
     app: st2api
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     release: {{ .Release.Name }}
   type: ClusterIP
   ports:
@@ -59,14 +59,14 @@ metadata:
     app: st2stream
     tier: backend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
     app: st2stream
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     release: {{ .Release.Name }}
   type: ClusterIP
   ports:
@@ -84,14 +84,14 @@ metadata:
     app: st2web
     tier: frontend
     vendor: stackstorm
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   selector:
     app: st2web
-    support: enterprise
+    support: {{ template "supportMethod" . }}
     release: {{ .Release.Name }}
   # TODO: Consider to template it, if needed
   type: NodePort

--- a/values.yaml
+++ b/values.yaml
@@ -5,8 +5,6 @@
 ## Docker image settings, applied to all StackStorm pods
 ##
 image:
-  # StackStorm Enterprise private Docker Registry used to pull images
-  repository: docker.stackstorm.com
   # Image pull policy. Change to "IfNotPresent" when switching to stable images
   pullPolicy: Always
 

--- a/values.yaml
+++ b/values.yaml
@@ -9,11 +9,11 @@ image:
   pullPolicy: Always
 
 ##
-## StackStorm Enterprise settings.
+## StackStorm Enterprise settings (Optional)
 ##
 enterprise:
-  # Enable/Disable StackStorm Enterprise. Disabling enterprise will download StackStorm community Docker images.
-  enabled: true
+  # Enable/Disable StackStorm Enterprise. Enabling will download StackStorm Enterprise Docker images.
+  enabled: false
   # Required StackStorm Enterprise license key.
   # Don't have one? Obtain 90-day free trial at https://stackstorm.com/#product
   license: ""

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,16 @@ image:
   pullPolicy: Always
 
 ##
+## StackStorm Enterprise settings.
+##
+enterprise:
+  # Enable/Disable StackStorm Enterprise. Disabling enterprise will download StackStorm community Docker images.
+  enabled: true
+  # Required StackStorm Enterprise license key.
+  # Don't have one? Obtain 90-day free trial at https://stackstorm.com/#product
+  license: ""
+
+##
 ## StackStorm shared variables
 ##
 st2:
@@ -86,9 +96,6 @@ st2:
 # TODO: Alternatively as part of reorganizing Helm values, consider moving values to existing `st2` and `st2web` sections ? (#14)
 secrets:
   st2:
-    # Required (!) StackStorm Enterprise license key.
-    # Don't have one? Obtain 90-day free trial at https://stackstorm.com/#product
-    license: ""
     # Username, used to login to StackStorm system
     username: st2admin
     # Password, used to login to StackStorm system

--- a/values.yaml
+++ b/values.yaml
@@ -1,4 +1,4 @@
-# Default values for StackStorm Enterprise HA cluster
+# Default values for StackStorm HA cluster
 # This is a YAML-formatted file.
 
 ##
@@ -65,7 +65,7 @@ st2:
   # Custom pack configs and image settings.
   #
   # By default, system packs are available. However, since 'st2 pack install' cannot be run in the k8s cluster,
-  # you will need to bake additional packs into an 'st2packs' image. Please see stackstorm-enterprise-ha/README.md
+  # you will need to bake additional packs into an 'st2packs' image. Please see github.com/stackstorm/stackstorm-ha/README.md
   # for details on how to build this image.
   packs:
     # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
@@ -87,7 +87,7 @@ st2:
       pullPolicy: Always
 
 ##
-## StackStorm Enterprise Cluster Secrets. All fields are required!
+## StackStorm HA Cluster Secrets. All fields are required!
 ## NB! It's highly recommended to change ALL defaults!
 ##
 # TODO: Move to `secrets.yaml` when it gets implemented in Helm (https://github.com/kubernetes/helm/issues/2196) ? (#14)
@@ -191,7 +191,7 @@ secrets:
       -----END PRIVATE KEY-----
 
 ##
-## StackStorm Enterprise Cluster pod settings for each individual service/component.
+## StackStorm HA Cluster pod settings for each individual service/component.
 ##
 # Many st2web instances, placed behind a load balancer that serve web app and proxify requests to st2auth, st2api, st2stream.
 st2web:

--- a/values.yaml
+++ b/values.yaml
@@ -20,40 +20,6 @@ enterprise:
   # Don't have one? Obtain 90-day free trial at https://stackstorm.com/#product
   license: ""
 
-##
-## StackStorm shared variables
-##
-st2:
-  # Custom StackStorm config (st2.user.conf) which will apply settings on top of default st2.conf
-  config: |
-    [api]
-    allow_origin = '*'
-
-
-  # Custom pack configs and image settings.
-  #
-  # By default, system packs are available. However, since 'st2 pack install' cannot be run in the k8s cluster,
-  # you will need to bake additional packs into an 'st2packs' image. Please see stackstorm-enterprise-ha/README.md
-  # for details on how to build this image.
-  packs:
-    # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
-    # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file
-    configs:
-      core.yaml: |
-        ---
-        # example core pack config yaml
-
-    # Custom packs image settings. The repository, name, tag and pullPolicy for this image
-    # are specified below.
-    image:
-      # If you wish to use a docker registry running in the k8s cluster, set docker-registry.enabled to true.
-      # Uncomment the following line to make the custom packs image available to the necessary pods.
-
-      # repository: localhost:5000
-      name: st2packs
-      tag: latest
-      pullPolicy: Always
-
   # StackStorm Role Based Access Control settings (https://docs.stackstorm.com/rbac.html)
   rbac:
     # Custom StackStorm RBAC roles, shipped in '/opt/stackstorm/rbac/roles/'
@@ -88,6 +54,40 @@ st2:
       #  description: "Automatically grant admin role to all stormers group members."
       #  roles:
       #    - "admin"
+
+##
+## StackStorm shared variables
+##
+st2:
+  # Custom StackStorm config (st2.user.conf) which will apply settings on top of default st2.conf
+  config: |
+    [api]
+    allow_origin = '*'
+
+  # Custom pack configs and image settings.
+  #
+  # By default, system packs are available. However, since 'st2 pack install' cannot be run in the k8s cluster,
+  # you will need to bake additional packs into an 'st2packs' image. Please see stackstorm-enterprise-ha/README.md
+  # for details on how to build this image.
+  packs:
+    # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
+    # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file
+    configs:
+      core.yaml: |
+        ---
+        # example core pack config yaml
+
+    # Custom packs image settings. The repository, name, tag and pullPolicy for this image
+    # are specified below.
+    image:
+      # If you wish to use a docker registry running in the k8s cluster, set docker-registry.enabled to true.
+      # Uncomment the following line to make the custom packs image available to the necessary pods.
+
+      # repository: localhost:5000
+      name: st2packs
+      tag: latest
+      pullPolicy: Always
+
 ##
 ## StackStorm Enterprise Cluster Secrets. All fields are required!
 ## NB! It's highly recommended to change ALL defaults!


### PR DESCRIPTION
Closes #22 

As discussed with @warrenvw we'll try to template both StackStorm FOSS Community and Enterprise versions in a single Helm chart as it has many benefits in the end, incl. easier code/community/documentation support and finally #2 adoption.

As the implementation goes, stackstorm community version will be configured by default and `enterprise` support will be optional and may be turned on via `enterprise.enabled: true` flag in Helm `values.yaml`. Depending on that flag Helm chart will use st2 community Docker images, otherwise switch to Enterprise images as well as enable/configure additional enterprise settings.

The change itself will need a massive documentation refactoring afterwards.

### TODO
- [x] `values.yaml` rework and additional templating
  - [x] `enterprise.license`
    - [x] must be required if `enterprise.enabled`
  - [x] rework `enterprise.rbac`
  - [x] `enterprise.enabled` templating
  - [x] CI enterprise/community
- [x] `stackstorm-enterprise-ha` -> `stackstorm-ha` chart/repo rename
- [x] Switch `enterprise` -> `community` by default
- [x] Requires Community Dockerfiles to be finished (WIP by @warrenvw)
- [ ] Documentation update
  - [x] master README update
  - [ ] gh-pages README update
  - [ ] st2docs enterprise
  - [ ] st2docs community
  - [ ] enterprise HA blog update
  - [ ] package + deploy new Helm release to helm.stackstorm.com
- [x] What if `enterprise.enabled` changed `true` -> `false` during Helm upgrade and vice-versa?
