### PR TITLE
Include a link to st2-dockerfiles github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See Helm `values.yaml`, `enterprise` section for configuration examples.
 
 ## Components
 
-The Dockerfiles used to generate the docker images for each of the following components are available at
+The Dockerfiles used to generate the docker images for each st2 component are available at
 github.com/stackstorm/st2-dockerfiles.
 
 ### st2client

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See Helm `values.yaml`, `enterprise` section for configuration examples.
 
 ## Components
 
-The Dockerfiles used to generate the docker images for each st2 component are available at
+The Community FOSS Dockerfiles used to generate the docker images for each st2 component are available at
 [st2-dockerfiles](https://github.com/stackstorm/st2-dockerfiles).
 
 ### st2client

--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ See Helm `values.yaml`, `enterprise` section for configuration examples.
 > 90-day free trial can be requested at https://stackstorm.com/#product
 
 ## Components
+
+The Dockerfiles used to generate the docker images for each of the following components are available at
+github.com/stackstorm/st2-dockerfiles.
+
 ### st2client
 A helper container to switch into and run st2 CLI commands against the deployed StackStorm cluster.
 All resources like credentials, configs, RBAC, packs, keys and secrets are shared with this container.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ See Helm `values.yaml`, `enterprise` section for configuration examples.
 ## Components
 
 The Dockerfiles used to generate the docker images for each st2 component are available at
-github.com/stackstorm/st2-dockerfiles.
+[st2-dockerfiles](https://github.com/stackstorm/st2-dockerfiles).
 
 ### st2client
 A helper container to switch into and run st2 CLI commands against the deployed StackStorm cluster.


### PR DESCRIPTION
Documentation should provide link to the st2-dockerfiles repo, where the images for st2 components are defined.