### PR TITLE
Helm 'st2.keyvalue' to import data into st2 K/V storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## In Development
-
+* Add new Helm `st2.keyvalue` to import data into st2 K/V storage  (#30)
 
 ## v0.6.0
 * Add StackStorm FOSS (community version), make Enterprise install optional (#22)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -2,6 +2,114 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  name: {{ .Release.Name }}-job-st2-key-load
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    support: {{ template "supportMethod" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: post-install, post-upgrade, post-rollback
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "5"
+spec:
+  template:
+    metadata:
+      name: job-st2-key-load
+      labels:
+        app: st2
+        tier: backend
+        vendor: stackstorm
+        support: {{ template "supportMethod" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      annotations:
+        # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-urls.yaml") . | sha256sum }}
+    spec:
+      {{- if .Values.enterprise.enabled }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      initContainers:
+      # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
+      - name: generate-st2client-config
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-st2-urls
+        env:
+        - name: ST2_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-st2-auth
+              key: username
+        - name: ST2_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-st2-auth
+              key: password
+        volumeMounts:
+        - name: st2client-config-vol
+          mountPath: /root/.st2/
+        # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
+        command:
+          - 'sh'
+          - '-ec'
+          - |
+            cat <<EOT > /root/.st2/config
+            [credentials]
+            username = ${ST2_AUTH_USERNAME}
+            password = ${ST2_AUTH_PASSWORD}
+            EOT
+      containers:
+      - name: st2-key-load
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - st2
+          - key
+          - load
+          - /etc/st2/st2kv.yaml
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-st2-urls
+        volumeMounts:
+        - name: st2-config-vol
+          mountPath: /etc/st2/st2.docker.conf
+          subPath: st2.docker.conf
+        - name: st2-config-vol
+          mountPath: /etc/st2/st2.user.conf
+          subPath: st2.user.conf
+        - name: st2client-config-vol
+          mountPath: /root/.st2/
+        - name: st2-kv-vol
+          mountPath: /etc/st2/st2kv.yaml
+          subPath: st2kv.yaml
+        # TODO: Find out default resource limits for this specific service (#5)
+        #resources:
+      volumes:
+        - name: st2-config-vol
+          configMap:
+            name: {{ .Release.Name }}-st2-config
+        - name: st2client-config-vol
+          emptyDir:
+            medium: Memory
+        - name: st2-kv-vol
+          secret:
+            secretName: {{ .Release.Name }}-st2-kv
+      restartPolicy: OnFailure
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
   name: {{ .Release.Name }}-job-st2-register-content
   labels:
     app: st2-register-content
@@ -14,7 +122,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install, post-upgrade, post-rollback
     helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "5"
+    helm.sh/hook-weight: "6"
 spec:
   template:
     metadata:

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -30,7 +30,7 @@ spec:
       annotations:
         # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-        checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-urls.yaml") . | sha256sum }}
+        checksum/urls: {{ include (print $.Template.BasePath "/configmaps_st2-urls.yaml") . | sha256sum }}
     spec:
       {{- if .Values.enterprise.enabled }}
       imagePullSecrets:

--- a/templates/secrets_st2kv.yaml
+++ b/templates/secrets_st2kv.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-st2-kv
+  annotations:
+    description: Key/Value pairs to save in StackStorm's datastore
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    support: {{ template "supportMethod" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  st2kv.yaml: {{ toYaml .Values.st2.keyvalue | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -85,6 +85,13 @@ st2:
       name: st2packs
       tag: latest
       pullPolicy: Always
+  # Import data into StackStorm's Key/Value datastore (https://docs.stackstorm.com/datastore.html)
+  keyvalue:
+    #- name: st2_version
+    #  scope: st2kv.system
+    #  secret: false
+    #  encrypted: false
+    #  value: "2.9"
 
 ##
 ## StackStorm HA Cluster Secrets. All fields are required!


### PR DESCRIPTION
Closes #7 

To import data into K/V K8s one-time job creates a file with user-supplied yaml data to import and performs `st2 key load st2kv.yaml` against it.