### PR TITLE
Add new st2 service st2scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 # Changelog
 
 ## In Development
+
+
+## v0.7.0
 * Add new Helm `st2.keyvalue` to import data into st2 K/V storage  (#30)
+* Include new st2 component `st2scheduler`, introduced since st2 `v3.0` (#32)
 
 ## v0.6.0
 * Add StackStorm FOSS (community version), make Enterprise install optional (#22)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.0dev
 name: stackstorm-ha
-version: 0.6.0
+version: 0.7.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/README.md
+++ b/README.md
@@ -102,6 +102,9 @@ All the workflow engine processes will share the load and pick up more work if o
 > As Mistral is going to be deprecated and removed from StackStorm platform soon, Helm chart relies only on
 >  [Orquesta st2workflowengine](https://docs.stackstorm.com/orchestra/index.html) as a new native workflow engine.
 
+### [st2scheduler](https://docs.stackstorm.com/reference/ha.html#st2scheduler)
+TODO: Description TBD
+
 ### [st2notifier](https://docs.stackstorm.com/reference/ha.html#st2notifier)
 Multiple st2notifier processes can run in active-active mode, using connections to RabbitMQ and MongoDB and generating triggers based on
 action execution completion as well as doing action rescheduling.

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -633,6 +633,80 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  name: {{ .Release.Name }}-st2scheduler{{ template "enterpriseSuffix" . }}
+  labels:
+    app: st2scheduler
+    tier: backend
+    vendor: stackstorm
+    support: {{ template "supportMethod" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    matchLabels:
+      app: st2scheduler
+      support: {{ template "supportMethod" . }}
+      release: {{ .Release.Name }}
+  # https://docs.stackstorm.com/reference/ha.html#st2scheduler
+  replicas: {{ default 2 .Values.st2scheduler.replicas }}
+  template:
+    metadata:
+      labels:
+        app: st2scheduler
+        tier: backend
+        vendor: stackstorm
+        support: {{ template "supportMethod" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+    spec:
+      {{- if .Values.enterprise.enabled }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      containers:
+      - name: st2scheduler{{ template "enterpriseSuffix" . }}
+        image: "{{ template "imageRepository" . }}/st2scheduler{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        # TODO: Add liveness/readiness probes (#3)
+        #livenessProbe:
+        #readinessProbe:
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-st2-urls
+        volumeMounts:
+        - name: st2-config-vol
+          mountPath: /etc/st2/st2.docker.conf
+          subPath: st2.docker.conf
+        - name: st2-config-vol
+          mountPath: /etc/st2/st2.user.conf
+          subPath: st2.user.conf
+        resources:
+{{ toYaml .Values.st2scheduler.resources | indent 10 }}
+      volumes:
+        - name: st2-config-vol
+          configMap:
+            name: {{ .Release.Name }}-st2-config
+    {{- with .Values.st2scheduler.nodeSelector }}
+      nodeSelector:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.st2scheduler.affinity }}
+      affinity:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+    {{- with .Values.st2scheduler.tolerations }}
+      tolerations:
+{{ toYaml . | indent 8 }}
+    {{- end }}
+
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
   name: {{ .Release.Name }}-st2notifier{{ template "enterpriseSuffix" . }}
   labels:
     app: st2notifier

--- a/values.yaml
+++ b/values.yaml
@@ -277,6 +277,16 @@ st2workflowengine:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+# https://docs.stackstorm.com/reference/ha.html#st2scheduler
+# TODO: Description TBD
+st2scheduler:
+  replicas: 2
+  # TODO: Find out recommended/default resources for this specific service (#5)
+  resources: {}
+  # Additional advanced settings to control pod/deployment placement
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 # https://docs.stackstorm.com/reference/ha.html#st2notifier
 # st2notifier runs in active-active mode and requires for that coordination backend like Redis or Zookeeper
 st2notifier:


### PR DESCRIPTION
Closes #31 

This PR codifies new st2 service `st2scheduler` which was introduced since st2 `v3.0`.

### TODO
- [x] st2-dockerfiles https://github.com/StackStorm/st2-dockerfiles/pull/10
- [x] st2enterprise-dockerfiles https://github.com/StackStorm/st2enterprise-dockerfiles/pull/97
- [x] K8s/Helm integration
- [ ] README
- [ ] Release `v0.7.0` chart

This PR needs Readme descriptions to be present in https://docs.stackstorm.com/reference/ha.html#st2scheduler cc @bigmstone 