### PR TITLE
Fix st2web re-deployment is not triggered when updating SSL cert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## In Development
 
 
+## v0.7.1
+* Fix st2web re-deployment is not triggered when updating SSL cert (#33)
+
 ## v0.7.0
 * Add new Helm `st2.keyvalue` to import data into st2 K/V storage  (#30)
 * Include new st2 component `st2scheduler`, introduced since st2 `v3.0` (#32)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.0dev
 name: stackstorm-ha
-version: 0.7.0
+version: 0.7.1
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -338,6 +338,8 @@ spec:
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+      annotations:
+        checksum/ssl: {{ include (print $.Template.BasePath "/secrets_st2web.yaml") . | sha256sum }}
     spec:
       {{- if .Values.enterprise.enabled }}
       imagePullSecrets:


### PR DESCRIPTION
Update of Helm values `secrets.st2web.` for SSL certificate doesn't trigger st2web re-deployment.

This PR fixes it so `st2web` deployment depends on SSL cert secret checksum via annotations.