### PR TITLE
Fix LoadBalancer templating to utilize correct service endpoints in NOTES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In Development
 
+## v0.8.2
+* Fix LoadBalancer templating to utilize correct service endpoints in NOTES (#39)
+
 ## v0.8.1
 * Ensure st2sensorcontainer is re-deployed on `st2.packs.configs` change (#37)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.0dev
 name: stackstorm-ha
-version: 0.8.1
+version: 0.8.2
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -11,15 +11,15 @@ Congratulations! You have just deployed StackStorm {{ if .Values.enterprise.enab
 {{- if contains "LoadBalancer" .Values.st2web.service.type }}
 
 NOTE: It may take a few minutes for the LoadBalancer IP to be available.
-      Watch the status with "kubectl get service st2cicd-st2web-enterprise -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"
+      Watch the status with "kubectl get service {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}'"
 
-export ST2WEB_IP=$(kubectl get service st2cicd-st2web-enterprise -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+export ST2WEB_IP=$(kubectl get service {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }} -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 echo https://${ST2WEB_IP}/
 
 {{- else if contains "ClusterIP" .Values.st2web.service.type }}
 
 echo https://127.0.0.1:8443
-kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ .Release.Name }}-st2web-{{ if .Values.enterprise.enabled }}-enterprise {{ end }} 8443:443
+kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }} 8443:443
 
 {{- end }}
 {{- if contains "NodePort" .Values.st2web.service.type }}


### PR DESCRIPTION
Previously st2web service endpoint was copy-pasted and hardcoded by mistake to `st2cicd` which resulted in wrong `ST2WEB_IP` showing up