### PR TITLE
Add support to specify images name and to enable HTTP for st2web

### DIFF
--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -63,7 +63,11 @@ spec:
           - printf "${ST2_AUTH_USERNAME}:$(openssl passwd -apr1 "${ST2_AUTH_PASSWORD}")\n" > /tmp/st2/htpasswd
       containers:
       - name: st2auth{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2auth.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2auth.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2auth{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9100
@@ -181,7 +185,11 @@ spec:
       {{- end }}
       containers:
       - name: st2api{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2api.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2api.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2api{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9101
@@ -272,7 +280,11 @@ spec:
       {{- end }}
       containers:
       - name: st2stream{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2stream.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2stream.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2stream{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9102
@@ -347,7 +359,11 @@ spec:
       {{- end }}
       containers:
       - name: st2web{{ template "enterpriseSuffix" . }}
-        image: "ggabriele/st2web"
+        {{ if .Values.st2web.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2web.image.imageName}}"
+        {{ else -}}
+        image: "{{ template "imageRepository" . }}/st2web{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         ports:
         - containerPort: 80
         # Probe to check if app is running. Failure will lead to a pod restart.
@@ -445,7 +461,11 @@ spec:
       {{- end }}
       containers:
       - name: st2rulesengine{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2rulesengine.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2rulesengine.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2rulesengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -521,7 +541,11 @@ spec:
       {{- end }}
       containers:
       - name: st2timersengine{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2timersengine.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2timersengine.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2timersengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -596,7 +620,11 @@ spec:
       {{- end }}
       containers:
       - name: st2workflowengine{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2workflowengine.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2workflowengine.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2workflowengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -670,7 +698,11 @@ spec:
       {{- end }}
       containers:
       - name: st2scheduler{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2scheduler.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2scheduler.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2scheduler{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -745,7 +777,11 @@ spec:
       {{- end }}
       containers:
       - name: st2notifier{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2notifier.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2notifier.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2notifier{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -856,7 +892,11 @@ spec:
       {{- end }}
       containers:
       - name: st2sensorcontainer{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2sensorcontainer.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2sensorcontainer.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2sensorcontainer{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -979,7 +1019,11 @@ spec:
       {{- end }}
       containers:
       - name: st2actionrunner{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2actionrunner.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2actionrunner.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -1079,7 +1123,11 @@ spec:
       {{- end }}
       containers:
       - name: st2garbagecollector{{ template "enterpriseSuffix" . }}
+        {{ if .Values.st2garbagecollector.image.imageName -}}
+        image: "{{.Values.secrets.images.customRegistry}}/{{.Values.st2garbagecollector.image.imageName}}"
+        {{ else -}}
         image: "{{ template "imageRepository" . }}/st2garbagecollector{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        {{ end -}}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -364,14 +364,27 @@ spec:
         {{ else -}}
         image: "{{ template "imageRepository" . }}/st2web{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         {{ end -}}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
+        {{ if .Values.st2web.protocol.http -}}
         - containerPort: 80
+        {{ else -}}
+        - containerPort: 443
+        {{ end -}}
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:
+            {{ if .Values.st2web.protocol.http -}}
             scheme: HTTP
+            {{ else -}}
+            scheme: HTTPS
+            {{ end -}}
             path: /
+            {{ if .Values.st2web.protocol.http -}}
             port: 80
+            {{ else -}}
+            port: 443
+            {{ end -}}
           initialDelaySeconds: 1
         # Probe to check if app is ready to serve traffic. Failure will lead to temp stop serving traffic.
         # TODO: Failing to add readinessProbe, since st2 requires authorization (401) and we don't have `/healthz` endpoints yet (https://github.com/StackStorm/st2/issues/4020)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -347,16 +347,15 @@ spec:
       {{- end }}
       containers:
       - name: st2web{{ template "enterpriseSuffix" . }}
-        image: "{{ template "imageRepository" . }}/st2web{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        image: "ggabriele/st2web"
         ports:
-        - containerPort: 443
+        - containerPort: 80
         # Probe to check if app is running. Failure will lead to a pod restart.
         livenessProbe:
           httpGet:
-            scheme: HTTPS
+            scheme: HTTP
             path: /
-            port: 443
+            port: 80
           initialDelaySeconds: 1
         # Probe to check if app is ready to serve traffic. Failure will lead to temp stop serving traffic.
         # TODO: Failing to add readinessProbe, since st2 requires authorization (401) and we don't have `/healthz` endpoints yet (https://github.com/StackStorm/st2/issues/4020)

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -107,4 +107,4 @@ spec:
   {{- end }}
   ports:
   - protocol: TCP
-    port: 443
+    port: 80

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -107,4 +107,8 @@ spec:
   {{- end }}
   ports:
   - protocol: TCP
+    {{ if .Values.st2web.protocol.http -}}
     port: 80
+    {{ else -}}
+    port: 443
+    {{ end -}}

--- a/values.yaml
+++ b/values.yaml
@@ -204,6 +204,8 @@ secrets:
 ##
 # Many st2web instances, placed behind a load balancer that serve web app and proxify requests to st2auth, st2api, st2stream.
 st2web:
+  protocol:
+    http: false
   # Minimum 2 replicas are recommended to run st2web in HA mode
   replicas: 2
   # Tested resource consumption based on multiple requests to st2web within nginx

--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,9 @@ st2:
 # TODO: Move to `secrets.yaml` when it gets implemented in Helm (https://github.com/kubernetes/helm/issues/2196) ? (#14)
 # TODO: Alternatively as part of reorganizing Helm values, consider moving values to existing `st2` and `st2web` sections ? (#14)
 secrets:
+  images:
+    # Pull images from a custom registry
+    customRegistry:
   st2:
     # Username, used to login to StackStorm system
     username: st2admin
@@ -196,7 +199,6 @@ secrets:
       ofUOhwAXuMsTtuLagOMyAJVs+KRVrvnXGT/p9l213ZAnDtFSpkvcjD9WUcupeTca
       BjdoJBzImjVB5znOgIui3ME5
       -----END PRIVATE KEY-----
-
 ##
 ## StackStorm HA Cluster pod settings for each individual service/component.
 ##
@@ -226,6 +228,8 @@ st2web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2auth
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
 st2auth:
@@ -236,6 +240,8 @@ st2auth:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2api
 # Multiple st2api process can be behind a load balancer in an active-active configuration.
 st2api:
@@ -246,6 +252,8 @@ st2api:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2stream
 # Multiple st2stream process can be behind a load balancer in an active-active configuration.
 st2stream:
@@ -256,6 +264,8 @@ st2stream:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2rulesengine
 # Multiple st2rulesengine processes can run in active-active with only connections to MongoDB and RabbitMQ. All these will share the TriggerInstance load and naturally pick up more work if one or more of the processes becomes unavailable.
 st2rulesengine:
@@ -266,6 +276,8 @@ st2rulesengine:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2timersengine
 # Only single replica is created via K8s Deployment as timersengine can't work in active-active mode at the moment and it relies on K8s failover/reschedule capabilities to address cases of process failure.
 st2timersengine:
@@ -275,6 +287,8 @@ st2timersengine:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2workflowengine
 # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
 st2workflowengine:
@@ -285,6 +299,8 @@ st2workflowengine:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2scheduler
 # TODO: Description TBD
 st2scheduler:
@@ -295,6 +311,8 @@ st2scheduler:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2notifier
 # st2notifier runs in active-active mode and requires for that coordination backend like Redis or Zookeeper
 st2notifier:
@@ -305,6 +323,8 @@ st2notifier:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
 # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance. Each sensor node needs to be
 # provided with proper partition information to share work with other sensor nodes so that the same sensor does not run on different nodes.
@@ -318,6 +338,8 @@ st2sensorcontainer:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2actionrunner
 # Multiple st2actionrunner processes can run in active-active with only connections to MongoDB and RabbitMQ. Work gets naturally
 # distributed across runners via RabbitMQ. Adding more st2actionrunner processes increases the ability of StackStorm to execute actions.
@@ -329,6 +351,8 @@ st2actionrunner:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.
 # By default this process does nothing and needs to be setup in st2.conf to perform any work.
@@ -341,6 +365,8 @@ st2garbagecollector:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  image:
+    imageName:
 
 ##
 ## MongoDB HA configuration (3rd party chart dependency)


### PR DESCRIPTION
Hello, this is an effort to add the possibility to specify the images name to pull from a custom registry. If no image name is specified, the default behavior is used.

I'm also enabling the toggling of HTTP/HTTPS for st2web (another PR to patch the st2web container will follow).

Let me know if any of this doesn't make sense :)