### PR TITLE
Add new Helm value setting 'st2.apikeys' to import ST2 API keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In Development
 
+## v0.9.0
+* Add new Helm value setting `st2.apikeys` to allow importing predefined ST2 API keys (#36)
+
 ## v0.8.4
 * Pin st2 version to `v3.0dev` as a new latest development version (#41)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.0dev
 name: stackstorm-ha
-version: 0.8.4
+version: 0.9.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -2,6 +2,105 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
+  name: {{ .Release.Name }}-job-st2-apikey-load
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    support: {{ template "supportMethod" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: post-install, post-upgrade, post-rollback
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "5"
+spec:
+  template:
+    metadata:
+      name: job-st2-apikey-load
+      labels:
+        app: st2
+        tier: backend
+        vendor: stackstorm
+        support: {{ template "supportMethod" . }}
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      annotations:
+        # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
+        checksum/urls: {{ include (print $.Template.BasePath "/configmaps_st2-urls.yaml") . | sha256sum }}
+        checksum/apikeys: {{ include (print $.Template.BasePath "/secrets_st2apikeys.yaml") . | sha256sum }}
+    spec:
+      {{- if .Values.enterprise.enabled }}
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      initContainers:
+      # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
+      - name: generate-st2client-config
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-st2-urls
+        env:
+        - name: ST2_AUTH_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-st2-auth
+              key: username
+        - name: ST2_AUTH_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-st2-auth
+              key: password
+        volumeMounts:
+        - name: st2client-config-vol
+          mountPath: /root/.st2/
+        # `st2 login` doesn't exit on failure correctly, use old methods instead. See bug: https://github.com/StackStorm/st2/issues/4338
+        command:
+          - 'sh'
+          - '-ec'
+          - |
+            cat <<EOT > /root/.st2/config
+            [credentials]
+            username = ${ST2_AUTH_USERNAME}
+            password = ${ST2_AUTH_PASSWORD}
+            EOT
+      containers:
+      - name: st2-apikey-load
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - st2
+          - apikey
+          - load
+          - /etc/st2/apikeys.yaml
+        envFrom:
+        - configMapRef:
+            name: {{ .Release.Name }}-st2-urls
+        volumeMounts:
+        - name: st2client-config-vol
+          mountPath: /root/.st2/
+        - name: st2-apikeys-vol
+          mountPath: /etc/st2/apikeys.yaml
+          subPath: apikeys.yaml
+        # TODO: Find out default resource limits for this specific service (#5)
+        #resources:
+      volumes:
+        - name: st2client-config-vol
+          emptyDir:
+            medium: Memory
+        - name: st2-apikeys-vol
+          secret:
+            secretName: {{ .Release.Name }}-st2-apikeys
+      restartPolicy: OnFailure
+
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
   name: {{ .Release.Name }}-job-st2-key-load
   labels:
     app: st2

--- a/templates/secrets_st2apikeys.yaml
+++ b/templates/secrets_st2apikeys.yaml
@@ -1,0 +1,18 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-st2-apikeys
+  annotations:
+    description: A list of StackStorm API keys with metadata that will be imported into the system
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    support: {{ template "supportMethod" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  apikeys.yaml: {{ toYaml .Values.st2.apikeys | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -92,6 +92,15 @@ st2:
     #  secret: false
     #  encrypted: false
     #  value: "2.9"
+  # Import a list of ST2 API Keys (https://docs.stackstorm.com/authentication.html#api-key-migration)
+  apikeys:
+    #- created_at: '2018-12-15T00:21:48.507388Z'
+    #  enabled: true
+    #  id: 5c14491c6cb8de1a9207e3a2
+    #  key_hash: 56928c2d9637ce44338e9564d4b939df8b258410db23b5a80f8ad69d58e648b574f35f9293c3a76bde263738be9aa8379a81553cd55513ad672540b7b0ec0cac
+    #  metadata: {"comment": "Example unsecure ST2 API key from K8s HA Helm values.yaml"}
+    #  uid: api_key:56928c2d9637ce44338e9564d4b939df8b258410db23b5a80f8ad69d58e648b574f35f9293c3a76bde263738be9aa8379a81553cd55513ad672540b7b0ec0cac
+    #  user: st2admin
 
 ##
 ## StackStorm HA Cluster Secrets. All fields are required!


### PR DESCRIPTION
Closes #36 

Implements https://docs.stackstorm.com/authentication.html#api-key-migration mechanism to import previously exported list of ST2 API keys that's needed for reproducible deployments.