### PR TITLE
Fix reference to socat image

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,8 +178,10 @@ kubectl port-forward $(kubectl get pod -l app=docker-registry -o jsonpath="{.ite
 
 NOTE: If running on MacOS, before deploying the image, open another terminal and execute:
 ```
-docker run --privileged --pid=host socat:latest nsenter -t 1 -u -n -i socat TCP-LISTEN:5000,fork TCP:docker.for.mac.localhost:5000
+docker run --privileged --pid=host stackstorm/socat:latest nsenter -t 1 -u -n -i socat TCP-LISTEN:5000,fork TCP:docker.for.mac.localhost:5000
 ```
+
+The source for the `stackstorm/socat` image is found at https://github.com/stackstorm/socat.
 
 To deploy the image to the registry, execute:
 ```


### PR DESCRIPTION
Resolves #42.

Although less than ideal, we created a `stackstorm/socat` image on Docker Hub which differs from `alpine/socat` in that it replaces the `ENTRYPOINT` instruction with `CMD`.

Update `README.md` with reference to `stackstorm/socat`.