### PR TITLE
Rename socat repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ kubectl port-forward $(kubectl get pod -l app=docker-registry -o jsonpath="{.ite
 
 NOTE: If running on MacOS, before deploying the image, open another terminal and execute:
 ```
-docker run --privileged --pid=host stackstorm/docker-socat:latest nsenter -t 1 -u -n -i socat TCP-LISTEN:5000,fork TCP:docker.for.mac.localhost:5000
+docker run --privileged --pid=host stackstorm/socat:latest nsenter -t 1 -u -n -i socat TCP-LISTEN:5000,fork TCP:docker.for.mac.localhost:5000
 ```
 
 The source for the `stackstorm/socat` image is found at https://github.com/StackStorm/docker-socat.

--- a/README.md
+++ b/README.md
@@ -178,10 +178,10 @@ kubectl port-forward $(kubectl get pod -l app=docker-registry -o jsonpath="{.ite
 
 NOTE: If running on MacOS, before deploying the image, open another terminal and execute:
 ```
-docker run --privileged --pid=host stackstorm/socat:latest nsenter -t 1 -u -n -i socat TCP-LISTEN:5000,fork TCP:docker.for.mac.localhost:5000
+docker run --privileged --pid=host stackstorm/docker-socat:latest nsenter -t 1 -u -n -i socat TCP-LISTEN:5000,fork TCP:docker.for.mac.localhost:5000
 ```
 
-The source for the `stackstorm/socat` image is found at https://github.com/StackStorm/socat.
+The source for the `stackstorm/docker-socat` image is found at https://github.com/StackStorm/docker-socat.
 
 To deploy the image to the registry, execute:
 ```

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ NOTE: If running on MacOS, before deploying the image, open another terminal and
 docker run --privileged --pid=host stackstorm/docker-socat:latest nsenter -t 1 -u -n -i socat TCP-LISTEN:5000,fork TCP:docker.for.mac.localhost:5000
 ```
 
-The source for the `stackstorm/docker-socat` image is found at https://github.com/StackStorm/docker-socat.
+The source for the `stackstorm/socat` image is found at https://github.com/StackStorm/docker-socat.
 
 To deploy the image to the registry, execute:
 ```


### PR DESCRIPTION
Rename repo from `StackStorm/socat` to `StackStorm/docker-socat`, based on https://github.com/StackStorm/stackstorm-ha/pull/46#pullrequestreview-201866334.