### PR TITLE
Fix improper job load order for enterprise edition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Replace single-node `etcd` coordination backend with 3-node etcd HA cluster, deployed as a Helm dependency (#52)
+* Fixed improper job load order for enterprise edition failing due to missing RBAC roles & assignments (#53)
 
 ## v0.9.0
 * Add new Helm value setting `st2.apikeys` to allow importing predefined ST2 API keys (#36)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -1,3 +1,81 @@
+{{ if .Values.enterprise.enabled }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-job-st2-apply-rbac-definitions
+  labels:
+    app: st2-apply-rbac-definitions
+    tier: backend
+    vendor: stackstorm
+    support: enterprise
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  annotations:
+    helm.sh/hook: post-install, post-upgrade, post-rollback
+    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-weight: "5"
+spec:
+  template:
+    metadata:
+      name: job-st2-apply-rbac-definitions
+      labels:
+        app: st2-apply-rbac-definitions
+        tier: backend
+        vendor: stackstorm
+        support: enterprise
+        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+        release: {{ .Release.Name }}
+        heritage: {{ .Release.Service }}
+      annotations:
+        # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        checksum/rbac: {{ include (print $.Template.BasePath "/configmaps_rbac.yaml") . | sha256sum }}
+    spec:
+      imagePullSecrets:
+      - name: {{ .Release.Name }}-st2-license
+      containers:
+      - name: st2-apply-rbac-definitions
+        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+          - st2-apply-rbac-definitions
+          - --verbose
+          - --config-file=/etc/st2/st2.conf
+          - --config-file=/etc/st2/st2.docker.conf
+          - --config-file=/etc/st2/st2.user.conf
+        volumeMounts:
+        - name: st2-config-vol
+          mountPath: /etc/st2/st2.docker.conf
+          subPath: st2.docker.conf
+        - name: st2-config-vol
+          mountPath: /etc/st2/st2.user.conf
+          subPath: st2.user.conf
+        - name: st2-rbac-roles-vol
+          mountPath: /opt/stackstorm/rbac/roles/
+        - name: st2-rbac-assignments-vol
+          mountPath: /opt/stackstorm/rbac/assignments/
+        - name: st2-rbac-mappings-vol
+          mountPath: /opt/stackstorm/rbac/mappings/
+        # TODO: Find out default resource limits for this specific service (#5)
+        #resources:
+      volumes:
+        - name: st2-config-vol
+          configMap:
+            name: {{ .Release.Name }}-st2-config
+        - name: st2-rbac-roles-vol
+          configMap:
+            name: {{ .Release.Name }}-st2-rbac-roles
+        - name: st2-rbac-assignments-vol
+          configMap:
+            name: {{ .Release.Name }}-st2-rbac-assignments
+        - name: st2-rbac-mappings-vol
+          configMap:
+            name: {{ .Release.Name }}-st2-rbac-mappings
+      restartPolicy: OnFailure
+{{ end }}
+
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,7 +92,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install, post-upgrade, post-rollback
     helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "5"
+    helm.sh/hook-weight: "6"
 spec:
   template:
     metadata:
@@ -113,7 +191,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install, post-upgrade, post-rollback
     helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "5"
+    helm.sh/hook-weight: "6"
 spec:
   template:
     metadata:
@@ -221,7 +299,7 @@ metadata:
   annotations:
     helm.sh/hook: post-install, post-upgrade, post-rollback
     helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "6"
+    helm.sh/hook-weight: "7"
 spec:
   template:
     metadata:
@@ -317,81 +395,3 @@ spec:
           emptyDir: {}
         {{- end }}
       restartPolicy: OnFailure
-
-{{ if .Values.enterprise.enabled }}
----
-apiVersion: batch/v1
-kind: Job
-metadata:
-  name: {{ .Release.Name }}-job-st2-apply-rbac-definitions
-  labels:
-    app: st2-apply-rbac-definitions
-    tier: backend
-    vendor: stackstorm
-    support: enterprise
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-  annotations:
-    helm.sh/hook: post-install, post-upgrade, post-rollback
-    helm.sh/hook-delete-policy: before-hook-creation
-    helm.sh/hook-weight: "6"
-spec:
-  template:
-    metadata:
-      name: job-st2-apply-rbac-definitions
-      labels:
-        app: st2-apply-rbac-definitions
-        tier: backend
-        vendor: stackstorm
-        support: enterprise
-        chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-        release: {{ .Release.Name }}
-        heritage: {{ .Release.Service }}
-      annotations:
-        # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
-        checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-        checksum/rbac: {{ include (print $.Template.BasePath "/configmaps_rbac.yaml") . | sha256sum }}
-    spec:
-      imagePullSecrets:
-      - name: {{ .Release.Name }}-st2-license
-      containers:
-      - name: st2-apply-rbac-definitions
-        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        command:
-          - st2-apply-rbac-definitions
-          - --verbose
-          - --config-file=/etc/st2/st2.conf
-          - --config-file=/etc/st2/st2.docker.conf
-          - --config-file=/etc/st2/st2.user.conf
-        volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
-        - name: st2-rbac-roles-vol
-          mountPath: /opt/stackstorm/rbac/roles/
-        - name: st2-rbac-assignments-vol
-          mountPath: /opt/stackstorm/rbac/assignments/
-        - name: st2-rbac-mappings-vol
-          mountPath: /opt/stackstorm/rbac/mappings/
-        # TODO: Find out default resource limits for this specific service (#5)
-        #resources:
-      volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
-        - name: st2-rbac-roles-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-rbac-roles
-        - name: st2-rbac-assignments-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-rbac-assignments
-        - name: st2-rbac-mappings-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-rbac-mappings
-      restartPolicy: OnFailure
-{{ end }}


### PR DESCRIPTION
The K8s jobs we're running should register RBAC roles and assignments first, otherwise other jobs are failing due to insufficient user permissions to run specific task (st2 key load, register content, etc).
