### PR TITLE
Pin etcd to latest 3 version as st2 won't work properly with etcd 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Pin etcd to latest 3 version per new st2 coordination requirement (#61)
 
 ## v0.10.0
 * Bump versions of all dependencies (#50)

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -21,6 +21,7 @@ data:
     [auth]
     api_url = http://{{ .Release.Name }}-st2api{{ template "enterpriseSuffix" . }}:9101/
     [coordination]
+    # TODO: Use 'etcd3+http' driver for tooz, per https://github.com/StackStorm/st2/pull/4608
     url = etcd://{{ .Release.Name }}-etcd:2379
     [messaging]
     # TODO: RabbitMQ HQ connection string needs templating based on number of nodes

--- a/values.yaml
+++ b/values.yaml
@@ -388,6 +388,9 @@ rabbitmq-ha:
 ## https://github.com/helm/charts/blob/master/incubator/etcd/values.yaml
 ##
 etcd:
+  image:
+    # At least etcd 'v3.0' is required by StackStorm
+    tag: "3.3.10"
   resources: {}
 
 ##


### PR DESCRIPTION
Closes #58

See https://github.com/StackStorm/st2/pull/4608 for more context.
st2 since `v3.0` will require newer version of etcd which supports groups/memberships 
See: https://docs.openstack.org/tooz/latest/reference/index.html#tooz.drivers.etcd3gw.Etcd3Driver
