### PR TITLE
Add support for ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In Development
 
+## v0.15.0
+* Add support for ingress (#68)
+
 ## v0.14.0
 * Pin st2 version to `v3.1dev` as a new latest development version (#67)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.1dev
 name: stackstorm-ha
-version: 0.14.0
+version: 0.15.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ See Helm `values.yaml`, `enterprise` section for configuration examples.
 
 The default configuration values for this chart are described in `values.yaml`.
 
+## Ingress
+
+Use an ingress if you need to expose HTTP and HTTPS routes from outside the cluster to services
+within the cluster. Ingress provides load balancing, SSL termination and name-based virtual
+hosting. See the ingress section in `values.yaml` for configuration details.
+
+You will need to deploy an ingress controller such as
+https://github.com/helm/charts/tree/master/incubator/aws-alb-ingress-controller or
+https://www.nginx.com/products/nginx/kubernetes-ingress-controller. More are available
+at https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/.
+
 ## Components
 
 The Community FOSS Dockerfiles used to generate the docker images for each st2 component are available at

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ See Helm `values.yaml`, `enterprise` section for configuration examples.
 > Don't have StackStorm Enterprise License?<br>
 > 90-day free trial can be requested at https://stackstorm.com/#product
 
+## Configuration
+
+The default configuration values for this chart are described in `values.yaml`.
+
 ## Components
 
 The Community FOSS Dockerfiles used to generate the docker images for each st2 component are available at

--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ The default configuration values for this chart are described in `values.yaml`.
 
 ## Ingress
 
-Use an ingress if you need to expose HTTP and HTTPS routes from outside the cluster to services
-within the cluster. Ingress provides load balancing, SSL termination and name-based virtual
-hosting. See the ingress section in `values.yaml` for configuration details.
+Ingress is worth considering if you want to expose multiple services under the same IP address, and
+these services all use the same L7 protocol (typically HTTP). You only pay for one load balancer if
+you are using native cloud integration, and because Ingress is "smart", you can get a lot of
+features out of the box (like SSL, Auth, Routing, etc.). See the ingress section in `values.yaml`
+for configuration details.
 
-You will need to deploy an ingress controller such as
-https://github.com/helm/charts/tree/master/incubator/aws-alb-ingress-controller or
-https://www.nginx.com/products/nginx/kubernetes-ingress-controller. More are available
-at https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/.
+You will first need to deploy an ingress controller of your preference. See
+https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/#additional-controllers
+for more information.
 
 ## Components
 

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -32,7 +32,7 @@ echo https://${ST2WEB_IP}:${ST2WEB_PORT}/
 {{- if .Values.ingress.enabled -}}
 Ingress is enabled. You may access following endpoints:
 {{- range .Values.ingress.hosts }}
-  {{- $host = .host -}}
+  {{- $host := .host -}}
   {{- range .paths }}
   http{{- if $.Values.ingress.tls }}s{{- end -}}://{{ $host }}{{ .path }}
   {{- end }}

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -21,13 +21,21 @@ echo https://${ST2WEB_IP}/
 echo https://127.0.0.1:8443
 kubectl port-forward --namespace {{ .Release.Namespace }} svc/{{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }} 8443:443
 
-{{- end }}
-{{- if contains "NodePort" .Values.st2web.service.type }}
+{{- else if contains "NodePort" .Values.st2web.service.type }}
 
 export ST2WEB_IP=$(minikube ip 2>/dev/null || kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
 export ST2WEB_PORT="$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }})"
 echo https://${ST2WEB_IP}:${ST2WEB_PORT}/
 
+{{- end }}
+
+{{- if .Values.ingress.enabled -}}
+Ingress is enabled. You may access following endpoints:
+{{- range .Values.ingress.hosts }}
+  {{- $host = .host -}}
+  {{- range .paths }}
+  http{{- if $.Values.ingress.tls }}s{{- end -}}://{{ $host }}{{ .path }}
+  {{- end }}
 {{- end }}
 
 2. Login with the following credentials:

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -37,6 +37,7 @@ Ingress is enabled. You may access following endpoints:
   http{{- if $.Values.ingress.tls }}s{{- end -}}://{{ $host }}{{ .path }}
   {{- end }}
 {{- end }}
+{{- end }}
 
 2. Login with the following credentials:
 username: {{ .Values.secrets.st2.username }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -3,13 +3,15 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  {{- $name := printf "%s-%s" $.Release.Name .Values.ingress.name | trunc 63 | trimSuffix "-" | quote }}
-  name: {{ $name }}
+  name: {{ .Release.Name }}-ingress{{ template "enterpriseSuffix" . }}
   labels:
-    app: {{ $name }}
-    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
-    release: "{{ $.Release.Name }}"
-    heritage: "{{ $.Release.Service }}"
+    app: ingress
+    tier: frontend
+    vendor: stackstorm
+    support: {{ template "supportMethod" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
   annotations:
     {{- if .Values.ingress.tls }}
     ingress.kubernetes.io/secure-backends: "true"
@@ -20,7 +22,7 @@ metadata:
 spec:
   rules:
   {{- range .Values.ingress.hosts }}
-  - host: {{ .name }}
+  - host: {{ .host }}
     http:
       paths:
       {{- range .paths }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -16,7 +16,7 @@ metadata:
     {{- if .Values.ingress.tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
-    {{- range $key, $value := .annotations }}
+    {{- range $key, $value := .Values.ingress.annotations }}
     {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -29,10 +29,9 @@ spec:
             serviceName: {{ .serviceName }}
             servicePort: {{ .servicePort }}
       {{- end }}
-  {{- if .tls }}
-  tls:
-  - hosts:
-    - {{ .Values.name }}
-    secretName: {{ .tlsSecret }}
   {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+{{ toYaml .Values.ingress.tls | indent 4 }}
+  {{- end -}}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,9 +1,9 @@
 {{- if .Values.ingress.enabled }}
-{{- range .Values.ingress.hosts }}
+---
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  {{- $name := printf "%s-%s" $.Release.Name .name | trunc 63 | trimSuffix "-" | quote }}
+  {{- $name := printf "%s-%s" $.Release.Name .Values.ingress.name | trunc 63 | trimSuffix "-" | quote }}
   name: {{ $name }}
   labels:
     app: {{ $name }}
@@ -11,7 +11,7 @@ metadata:
     release: "{{ $.Release.Name }}"
     heritage: "{{ $.Release.Service }}"
   annotations:
-    {{- if .tls }}
+    {{- if .Values.ingress.tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
     {{- range $key, $value := .annotations }}
@@ -19,7 +19,8 @@ metadata:
     {{- end }}
 spec:
   rules:
-  - host: {{ .host }}
+  {{- range .Values.ingress.hosts }}
+  - host: {{ .name }}
     http:
       paths:
       {{- range .paths }}
@@ -28,12 +29,10 @@ spec:
             serviceName: {{ .serviceName }}
             servicePort: {{ .servicePort }}
       {{- end }}
-{{- if .tls }}
+  {{- if .tls }}
   tls:
   - hosts:
-    - {{ .name }}
+    - {{ .Values.name }}
     secretName: {{ .tlsSecret }}
-{{- end }}
----
-{{- end }}
+  {{- end }}
 {{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -33,7 +33,7 @@ spec:
       {{- end }}
   {{- else }}
     {{- if required "Missing context '.Values.st2web.service.hostname'!" .Values.st2web.service.hostname }}
-  - hosts: {{ .Values.st2web.service.hostname }}
+  - host: {{ .Values.st2web.service.hostname }}
     {{- end }}
     http:
       paths:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,1 +1,39 @@
-# TODO: Research & add Ingress controller for exposing st2web service to public net (#6)
+{{- if .Values.ingress.enabled }}
+{{- range .Values.ingress.hosts }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  {{- $name := printf "%s-%s" $.Release.Name .name | trunc 63 | trimSuffix "-" | quote }}
+  name: {{ $name }}
+  labels:
+    app: {{ $name }}
+    chart: "{{ $.Chart.Name }}-{{ $.Chart.Version }}"
+    release: "{{ $.Release.Name }}"
+    heritage: "{{ $.Release.Service }}"
+  annotations:
+    {{- if .tls }}
+    ingress.kubernetes.io/secure-backends: "true"
+    {{- end }}
+    {{- range $key, $value := .annotations }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
+spec:
+  rules:
+  - host: {{ .host }}
+    http:
+      paths:
+      {{- range .paths }}
+        - path: {{ default "/" .path }}
+          backend:
+            serviceName: {{ .serviceName }}
+            servicePort: {{ .servicePort }}
+      {{- end }}
+{{- if .tls }}
+  tls:
+  - hosts:
+    - {{ .name }}
+    secretName: {{ .tlsSecret }}
+{{- end }}
+---
+{{- end }}
+{{- end }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -23,7 +23,7 @@ spec:
     http:
       paths:
       {{- range .paths }}
-        - path: {{ default "/" .path }}
+        - path: {{ default "/*" .path }}
           backend:
             serviceName: {{ .serviceName }}
             servicePort: {{ .servicePort }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -31,6 +31,16 @@ spec:
             serviceName: {{ .serviceName }}
             servicePort: {{ .servicePort }}
       {{- end }}
+  {{- else }}
+    {{- if required "Missing context '.Values.st2web.service.hostname'!" .Values.st2web.service.hostname }}
+  - hosts: {{ .Values.st2web.service.hostname }}
+    {{- end }}
+    http:
+      paths:
+        - path: "/*"
+          backend:
+            serviceName: {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }}
+            servicePort: "443"
   {{- end }}
   {{- if .Values.ingress.tls }}
   tls:

--- a/values.yaml
+++ b/values.yaml
@@ -120,6 +120,9 @@ st2:
     #  uid: api_key:56928c2d9637ce44338e9564d4b939df8b258410db23b5a80f8ad69d58e648b574f35f9293c3a76bde263738be9aa8379a81553cd55513ad672540b7b0ec0cac
     #  user: st2admin
 
+ingress:
+  enabled: false
+
 ##
 ## StackStorm HA Cluster Secrets. All fields are required!
 ## NB! It's highly recommended to change ALL defaults!

--- a/values.yaml
+++ b/values.yaml
@@ -132,8 +132,7 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   # Map hosts to paths
   hosts: []
-  # - name: chart-example.test
-  #   host: hostname.domain.tld
+  # - host: hostname.domain.tld
   #   # Map paths to services
   #   paths:
   #     - path: /

--- a/values.yaml
+++ b/values.yaml
@@ -120,8 +120,30 @@ st2:
     #  uid: api_key:56928c2d9637ce44338e9564d4b939df8b258410db23b5a80f8ad69d58e648b574f35f9293c3a76bde263738be9aa8379a81553cd55513ad672540b7b0ec0cac
     #  user: st2admin
 
+##
+## StackStorm HA Ingress
+##
 ingress:
+  # As recommended, ingress is disabled by default.
   enabled: false
+  # Annotations are used to configure the ingress controller
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  # Map hosts to paths
+  hosts: []
+  # - name: chart-example.test
+  #   host: hostname.domain.tld
+  #   # Map paths to services
+  #   paths:
+  #     - path: /
+  #       serviceName: service
+  #       servicePort: port
+  # Secure the Ingress by specifying a secret that contains a TLS private key and certificate
+  tls: []
+  # - secretName: chart-example-tls
+  #   hosts:
+  #     - chart-example.test
 
 ##
 ## StackStorm HA Cluster Secrets. All fields are required!

--- a/values.yaml
+++ b/values.yaml
@@ -133,9 +133,8 @@ ingress:
   # Map hosts to paths
   hosts: []
   # - host: hostname.domain.tld
-  #   NOTE: Both path and service details are optional. A working default will be used to
-  #   automatically configure st2web for ingress.
-  #
+  #   # NOTE: Both path and service details are optional. A working default will be used to
+  #   # automatically configure st2web for ingress.
   #   # Map paths to services
   #   paths:
   #     - path: /

--- a/values.yaml
+++ b/values.yaml
@@ -133,6 +133,9 @@ ingress:
   # Map hosts to paths
   hosts: []
   # - host: hostname.domain.tld
+  #   NOTE: Both path and service details are optional. A working default will be used to
+  #   automatically configure st2web for ingress.
+  #
   #   # Map paths to services
   #   paths:
   #     - path: /


### PR DESCRIPTION
See #6 for more details. The following change is made in this PR:

> Expose Ingress controller settings via Helm `values.yaml` to allow users to configure the SSL/TLS negotiation layer on their own (optional).

The ALB is configured using annotations. For example:

```
annotations:
  kubernetes.io/ingress.class: alb
  alb.ingress.kubernetes.io/backend-protocol: HTTP
  alb.ingress.kubernetes.io/scheme: internet-facing
  alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS": 443}]'
  alb.ingress.kubernetes.io/certificate-arn: ******
  ...
```

Remaining tasks:
- [ ] Additional testing
- [x] Update `Chart.yaml` with next minor `version`.
- [x] Update `CHANGELOG.md`