### PR TITLE
Compose MongoDB-HA cluster connection string for many nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v0.20.0
 * Add option to disable MongoDB and RabbitMQ in-cluster deployment and configuration (#79)
+* Compose multi-node connection string for MongoDB cluster instead of using loadbalancer single host (#80)
 
 ## v0.19.0
 * Configure RabbitMQ Queue mirroring by default, see https://www.rabbitmq.com/ha.html (#78)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.2dev
 name: stackstorm-ha
-version: 0.19.0
+version: 0.20.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq-ha.enabled
   - name: mongodb-replicaset
-    version: 3.9.2
+    version: 3.9.6
     repository: https://kubernetes-charts.storage.googleapis.com/
     alias: mongodb-ha
     condition: mongodb-ha.enabled

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -32,3 +32,28 @@ stackstorm
 {{- define "hyphenPrefix" -}}
 {{ if . }}-{{ . }}{{end}}
 {{- end -}}
+
+# Allow calling helpers from nested sub-chart
+# https://stackoverflow.com/a/52024583/4533625
+# https://github.com/helm/helm/issues/4535#issuecomment-477778391
+# Usage: "{{ include "nested" (list . "mongodb-ha" "mongodb-replicaset.fullname") }}"
+{{- define "nested" }}
+{{- $dot := index . 0 }}
+{{- $subchart := index . 1 | splitList "." }}
+{{- $template := index . 2 }}
+{{- $values := $dot.Values }}
+{{- range $subchart }}
+{{- $values = index $values . }}
+{{- end }}
+{{- include $template (dict "Chart" (dict "Name" (last $subchart)) "Values" $values "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
+{{- end }}
+
+# Generate comma-separated list of nodes for MongoDB-HA connection string, based on number of replicas and service name
+{{- define "mongodb-ha-nodes" -}}
+{{- $replicas := (int (index .Values "mongodb-ha" "replicas")) }}
+{{- $mongo_fullname := include "nested" (list $ "mongodb-ha" "mongodb-replicaset.fullname") }}
+  {{- range $index0 := until $replicas -}}
+    {{- $index1 := $index0 | add1 -}}
+{{ $mongo_fullname }}-{{ $index0 }}.{{ $mongo_fullname }}{{ if ne $index1 $replicas }},{{ end }}
+  {{- end -}}
+{{- end -}}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -22,18 +22,20 @@ data:
     api_url = http://{{ .Release.Name }}-st2api{{ template "enterpriseSuffix" . }}:9101/
     [coordination]
     url = etcd://{{ .Release.Name }}-etcd:2379
-    [messaging]
     {{- if index .Values "rabbitmq-ha" "enabled" }}
+    [messaging]
     url = amqp://{{ required "rabbitmq-ha.rabbitmqUsername is required!" (index .Values "rabbitmq-ha" "rabbitmqUsername") }}:{{ required "rabbitmq-ha.rabbitmqPassword is required!" (index .Values "rabbitmq-ha" "rabbitmqPassword") }}@{{ .Release.Name }}-rabbitmq-ha-discovery:5672
     {{- end }}
-    [database]
     {{- if index .Values "mongodb-ha" "enabled" }}
-    # TODO: ReplicaSet connection string needs templating based on number of MongoDB nodes
+    [database]
     {{- if index .Values "mongodb-ha" "auth" "enabled" }}
-    host = mongodb://{{ required "mongodb-ha.auth.adminUser is required!" (index .Values "mongodb-ha" "auth" "adminUser") }}:{{ required "mongodb-ha.auth.adminPassword is required!" (index .Values "mongodb-ha" "auth" "adminPassword") }}@{{ .Release.Name }}-mongodb-ha/?authSource=admin&replicaSet=rs0
-    {{ else }}
-    host = mongodb://{{ .Release.Name }}-mongodb-ha/?replicaSet=rs0
+    host = mongodb://{{ template "mongodb-ha-nodes" $ }}/?authSource=admin&replicaSet={{ index .Values "mongodb-ha" "replicaSetName" }}
+    username = {{ required "mongodb-ha.auth.adminUser is required!" (index .Values "mongodb-ha" "auth" "adminUser") }}
+    password = {{ required "mongodb-ha.auth.adminPassword is required!" (index .Values "mongodb-ha" "auth" "adminPassword") }}
+    {{- else }}
+    host = mongodb://{{ template "mongodb-ha-nodes" $ }}/?replicaSet={{ index .Values "mongodb-ha" "replicaSetName" }}
     {{- end }}
+    port = {{ index .Values "mongodb-ha" "port" }}
     {{- end }}
 
   # User-defined st2 config with custom settings applied on top of everything else.


### PR DESCRIPTION
Rely on multi-node connection string for MongoDB-HA cluster instead of using loadbalancer single host which is not desired for prod deployment.

See https://api.mongodb.com/python/current/examples/high_availability.html#mongos-load-balancing
> Warning
> Do not connect PyMongo to a pool of mongos instances through a load balancer. A single socket connection must always be routed to the same mongos instance for proper cursor support.