### PR TITLE
Add an option to pull custom st2pack image from private Docker repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In Development
 
+## v0.22.0
+* Add an option to pull custom st2packs image from private Docker repository (#87)
+
 ## v0.21.0
 * Change etcd dependency from incubator/etcd to stable/etcd-operator (#81)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.2dev
 name: stackstorm-ha
-version: 0.21.0
+version: 0.22.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/README.md
+++ b/README.md
@@ -231,6 +231,16 @@ To deploy the image to the registry, execute:
 docker push ${DOCKER_REGISTRY}/st2packs:latest
 ```
 
+### Pull st2packs from a private Docker registry
+If you need to pull your packs Docker image from a private registry, you need to create a Kubernetes Docker registry secret and pass it to helm.
+See [K8s documentation](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) for more info.
+```
+# Create a Docker registry secret called 'st2packs-auth'
+kubectl create secret docker-registry st2packs-auth --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-password>
+```
+
+Once secret created, you pass its name to helm value: `st2.packs.image.pullSecret`.
+
 ### How to provide custom pack configs
 Update the `pack.configs` section of `stackstorm-ha/values.yaml`:
 

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -141,9 +141,12 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.st2.packs.image.imagePullSecret }}
+      - name: {{ .Values.st2.packs.image.imagePullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
@@ -802,9 +805,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") $ | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") $ | sha256sum }}
     spec:
-      {{- if $.Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if $.Values.enterprise.enabled }}
       - name: {{ $.Release.Name }}-st2-license
+      {{- end }}
+      {{- if $.Values.st2.packs.image.imagePullSecret }}
+      - name: {{ $.Values.st2.packs.image.imagePullSecret }}
       {{- end }}
       {{- if $.Values.st2.packs.image.repository }}
       initContainers:
@@ -941,9 +947,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.st2.packs.image.imagePullSecret }}
+      - name: {{ .Values.st2.packs.image.imagePullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
@@ -1152,9 +1161,12 @@ spec:
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.st2.packs.image.imagePullSecret }}
+      - name: {{ .Values.st2.packs.image.imagePullSecret }}
       {{- end }}
       initContainers:
       {{- if .Values.st2.packs.image.repository }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -145,8 +145,8 @@ spec:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
-      {{- if .Values.st2.packs.image.imagePullSecret }}
-      - name: {{ .Values.st2.packs.image.imagePullSecret }}
+      {{- if .Values.st2.packs.image.pullSecret }}
+      - name: {{ .Values.st2.packs.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
@@ -809,8 +809,8 @@ spec:
       {{- if $.Values.enterprise.enabled }}
       - name: {{ $.Release.Name }}-st2-license
       {{- end }}
-      {{- if $.Values.st2.packs.image.imagePullSecret }}
-      - name: {{ $.Values.st2.packs.image.imagePullSecret }}
+      {{- if $.Values.st2.packs.image.pullSecret }}
+      - name: {{ $.Values.st2.packs.image.pullSecret }}
       {{- end }}
       {{- if $.Values.st2.packs.image.repository }}
       initContainers:
@@ -951,8 +951,8 @@ spec:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
-      {{- if .Values.st2.packs.image.imagePullSecret }}
-      - name: {{ .Values.st2.packs.image.imagePullSecret }}
+      {{- if .Values.st2.packs.image.pullSecret }}
+      - name: {{ .Values.st2.packs.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
@@ -1165,8 +1165,8 @@ spec:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
-      {{- if .Values.st2.packs.image.imagePullSecret }}
-      - name: {{ .Values.st2.packs.image.imagePullSecret }}
+      {{- if .Values.st2.packs.image.pullSecret }}
+      - name: {{ .Values.st2.packs.image.pullSecret }}
       {{- end }}
       initContainers:
       {{- if .Values.st2.packs.image.repository }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -317,9 +317,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.st2.packs.image.imagePullSecret }}
+      - name: {{ .Values.st2.packs.image.imagePullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -321,8 +321,8 @@ spec:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
-      {{- if .Values.st2.packs.image.imagePullSecret }}
-      - name: {{ .Values.st2.packs.image.imagePullSecret }}
+      {{- if .Values.st2.packs.image.pullSecret }}
+      - name: {{ .Values.st2.packs.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:

--- a/values.yaml
+++ b/values.yaml
@@ -85,8 +85,8 @@ st2:
       name: st2packs
       tag: latest
       pullPolicy: Always
-      # Optional name of the imagePullSecret secret if your custom packs image is hosted by private Docker registry with auth
-      # pullSecret: st2packs-auth
+      # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry behind the auth
+      #pullSecret: st2packs-auth
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.

--- a/values.yaml
+++ b/values.yaml
@@ -85,6 +85,8 @@ st2:
       name: st2packs
       tag: latest
       pullPolicy: Always
+      # Optional name of the imagePullSecret secret if your custom packs image is hosted by private Docker registry with auth
+      # imagePullSecret: st2packs-auth
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.

--- a/values.yaml
+++ b/values.yaml
@@ -86,7 +86,7 @@ st2:
       tag: latest
       pullPolicy: Always
       # Optional name of the imagePullSecret secret if your custom packs image is hosted by private Docker registry with auth
-      # imagePullSecret: st2packs-auth
+      # pullSecret: st2packs-auth
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.


### PR DESCRIPTION
Closes #86 

Add `imagePullSecret` in Helm values to allow pulling custom st2packs image from the Docker registry behind the auth (private image repository).
