### PR TITLE
Remove local Docker registry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
             helm dependency update
       - run:
           name: Helm install stackstorm-ha chart (Community)
-          command: helm install --timeout 500 --debug --wait --name stackstorm-ha .
+          command: helm install --timeout 600 --debug --wait --name stackstorm-ha .
       - run:
           name: Helm test (Community)
           command: helm test stackstorm-ha --parallel --cleanup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## v0.22.0
 * Add an option to pull custom st2packs image from private Docker repository (#87)
+* Remove local 'docker-registry' dependency for hosting custom packs in-cluster that doesn't fit prod expectations (#89)
 
 ## v0.21.0
 * Change etcd dependency from incubator/etcd to stable/etcd-operator (#81)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## v0.22.0
 * Add an option to pull custom st2packs image from private Docker repository (#87)
-* Remove local 'docker-registry' dependency for hosting custom packs in-cluster that doesn't fit prod expectations (#89)
+* Remove local 'docker-registry' dependency for hosting custom packs in-cluster that doesn't fit prod expectations (#88)
 
 ## v0.21.0
 * Change etcd dependency from incubator/etcd to stable/etcd-operator (#81)

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ StackStorm employs etcd as a distributed coordination backend, required for st2 
 As any other Helm dependency, it's possible to further configure it for specific scaling needs via `values.yaml`.
 
 ## Install custom st2 packs in the cluster
-In the Kubernetes cluster `st2 pack install` won’t work in a distributed environment.
+In distributed environment of the Kubernetes cluster `st2 pack install` won’t work.
 Instead, you need to bake the packs into a custom docker image, push it to a private or public docker registry and reference that image in Helm values.
 Helm chart will take it from there, sharing `/opt/stackstorm/{packs,virtualenvs}` via a sidecar container in pods which require access to the packs.
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -8,14 +8,6 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     alias: mongodb-ha
     condition: mongodb-ha.enabled
-  - name: docker-registry
-    version: 1.7.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: docker-registry.enabled
-  - name: kube-registry-proxy
-    version: 0.3.0
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-    condition: docker-registry.enabled
   - name: external-dns
     version: 1.6.1
     repository: https://kubernetes-charts.storage.googleapis.com/

--- a/values.yaml
+++ b/values.yaml
@@ -78,10 +78,8 @@ st2:
     # Custom packs image settings. The repository, name, tag and pullPolicy for this image
     # are specified below.
     image:
-      # If you wish to use a docker registry running in the k8s cluster, set docker-registry.enabled to true.
-      # Uncomment the following line to make the custom packs image available to the necessary pods.
-
-      # repository: localhost:5000
+      # Uncomment the following block to make the custom packs image available to the necessary pods
+      #repository: you-remote-docker-registry.io
       name: st2packs
       tag: latest
       pullPolicy: Always
@@ -413,36 +411,6 @@ etcd-operator:
   customResources:
     # create default etcd cluster
     createEtcdClusterCRD: true
-
-##
-## Docker registry configuration (3rd party chart dependency)
-##
-## The docker registry is useful if custom images need to be made available in the cluster.
-##
-## For values.yaml reference:
-## https://github.com/helm/charts/tree/master/stable/docker-registry
-##
-## If enabled is true, helm installs a docker registry into the cluster.
-## Otherwise, the docker registry is not installed.
-##
-docker-registry:
-  enabled: false
-  fullnameOverride: st2packs-docker-registry
-
-##
-## Docker registry proxy configuration (3rd party chart dependency)
-## (only installed if docker-registry is enabled)
-##
-## This is run on each k8s node, and proxies pod localhost:5000 to the docker registry
-##
-## For values.yaml reference:
-## https://github.com/helm/charts/tree/master/incubator/kube-registry-proxy
-##
-kube-registry-proxy:
-  registry:
-    host: st2packs-docker-registry.default.svc.cluster.local
-    port: 5000
-  hostPort: 5000
 
 ##
 ## External DNS configuration (3rd party chart dependency)


### PR DESCRIPTION
Remove local 'docker-registry' dependency for hosting custom packs in cluster that doesn't fit prod expectations. Simplify Helm chart a bit.