### PR TITLE
Fix MongoDB connection string templating for Helm 2.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In Development
 
+## v0.22.1
+* Fix MongoDB connection string templating due to regression in Helm 2.15 (#89)
+
 ## v0.22.0
 * Add an option to pull custom st2packs image from private Docker repository (#87)
 * Remove local 'docker-registry' dependency for hosting custom packs in-cluster that doesn't fit prod expectations (#88)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.2dev
 name: stackstorm-ha
-version: 0.22.0
+version: 0.22.1
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -50,7 +50,7 @@ stackstorm
 
 # Generate comma-separated list of nodes for MongoDB-HA connection string, based on number of replicas and service name
 {{- define "mongodb-ha-nodes" -}}
-{{- $replicas := (int (index .Values "mongodb-ha" "replicas")) }}
+{{- $replicas := (int (toString (index .Values "mongodb-ha" "replicas"))) }}
 {{- $mongo_fullname := include "nested" (list $ "mongodb-ha" "mongodb-replicaset.fullname") }}
   {{- range $index0 := until $replicas -}}
     {{- $index1 := $index0 | add1 -}}


### PR DESCRIPTION
Fixes https://github.com/StackStorm/stackstorm-ha/issues/89 where Helm templating failed to generate connection string for MongoDB cluster.

For some reason `index .Values "mongodb-ha" "replicas"` now returns `json.Number` instead of `float64` and so conversion failed in Helm `v2.15`, previously worked in `v2.14` (See https://github.com/helm/helm/issues/6708 for details).