### PR TITLE
Pin Helm to v2.x

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
   helm-lint:
     working_directory: ~/stackstorm-ha
     docker:
+      # Pin Helm to v2.x, see https://github.com/StackStorm/stackstorm-ha/issues/98
       - image: lachlanevenson/k8s-helm:v2.16.1
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
   helm-lint:
     working_directory: ~/stackstorm-ha
     docker:
-      - image: lachlanevenson/k8s-helm
+      - image: lachlanevenson/k8s-helm:v2.16.1
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,8 +73,8 @@ jobs:
       - checkout
       - kubernetes/install
       - minikube/minikube-install:
-          # Temporary pin minikube to 1.2.0 due to regression in 1.3.0 (https://github.com/kubernetes/minikube/issues/5014)
-          version: v1.2.0
+          # TODO: Update Minikube to latest, switch to new K8s version
+          version: v1.3.1
       - run:
           name: Create new K8s cluster
           command: sudo -E minikube start --vm-driver=none --cpus $(nproc) --memory 4096

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,10 @@ version: 2.1
 orbs:
   # https://circleci.com/orbs/registry/orb/circleci/kubernetes
   kubernetes: circleci/kubernetes@0.3.0
+  # Pins Helm to v2.x
+  # TODO: Consider upgrading Helm to v3.0 (https://github.com/StackStorm/stackstorm-ha/issues/98)
   # https://circleci.com/orbs/registry/orb/circleci/helm
-  helm: circleci/helm@0.1.2
+  helm: circleci/helm@0.2.0
   # https://circleci.com/orbs/registry/orb/ccpgames/minikube
   minikube: ccpgames/minikube@0.0.1
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It's more than welcome to fine-tune each component settings to fit specific avai
 
 ## Requirements
 * [Kubernetes](https://kubernetes.io/docs/setup/pick-right-solution/) cluster
-* [Helm](https://docs.helm.sh/using_helm/#install-helm) and [Tiller](https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller)
+* [Helm](https://docs.helm.sh/using_helm/#install-helm) and [Tiller](https://docs.helm.sh/using_helm/#initialize-helm-and-install-tiller) `v2.x`
 
 ## Usage
 1) Edit `values.yaml` with configuration for the StackStorm HA K8s cluster.


### PR DESCRIPTION
Helm `v3.0` was released (See #98).

This PR pins Helm version to `v2.x` before considering switching to `v3.x`