### PR TITLE
Switch to latest K8s 1.16

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,10 +72,12 @@ jobs:
     steps:
       - checkout
       - kubernetes/install
-      - minikube/minikube-install
+      - minikube/minikube-install:
+          # https://github.com/kubernetes/minikube/releases
+          version: v1.5.2
       - run:
           name: Create new K8s cluster
-          command: sudo -E minikube start --vm-driver=none --kubernetes-version=v1.16.3 --cpus $(nproc) --memory 4096 --extra-config kubeadm.ignore-preflight-errors=SystemVerification
+          command: sudo -E minikube start --vm-driver=none --cpus $(nproc) --memory 4096
           environment:
             CHANGE_MINIKUBE_NONE_USER: true
       - helm/install-helm-on-cluster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,9 +72,7 @@ jobs:
     steps:
       - checkout
       - kubernetes/install
-      - minikube/minikube-install:
-          # TODO: Update Minikube to latest, switch to new K8s version
-          version: v1.3.1
+      - minikube/minikube-install
       - run:
           name: Create new K8s cluster
           command: sudo -E minikube start --vm-driver=none --cpus $(nproc) --memory 4096

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - minikube/minikube-install
       - run:
           name: Create new K8s cluster
-          command: sudo -E minikube start --vm-driver=none --cpus $(nproc) --memory 4096
+          command: sudo -E minikube start --vm-driver=none --cpus $(nproc) --memory 4096 --extra-config kubeadm.ignore-preflight-errors=SystemVerification
           environment:
             CHANGE_MINIKUBE_NONE_USER: true
       - helm/install-helm-on-cluster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # Add additional CircleCI Orbs dependencies
 orbs:
   # https://circleci.com/orbs/registry/orb/circleci/kubernetes
-  kubernetes: circleci/kubernetes@0.3.0
+  kubernetes: circleci/kubernetes@0.10.1
   # Pins Helm to v2.x
   # TODO: Consider upgrading Helm to v3.0 (https://github.com/StackStorm/stackstorm-ha/issues/98)
   # https://circleci.com/orbs/registry/orb/circleci/helm
@@ -75,7 +75,7 @@ jobs:
       - minikube/minikube-install
       - run:
           name: Create new K8s cluster
-          command: sudo -E minikube start --vm-driver=none --cpus $(nproc) --memory 4096 --extra-config kubeadm.ignore-preflight-errors=SystemVerification
+          command: sudo -E minikube start --vm-driver=none --kubernetes-version=v1.16.3 --cpus $(nproc) --memory 4096 --extra-config kubeadm.ignore-preflight-errors=SystemVerification
           environment:
             CHANGE_MINIKUBE_NONE_USER: true
       - helm/install-helm-on-cluster

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: rabbitmq-ha
-    version: 1.31.0
+    version: 1.36.4
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq-ha.enabled
   - name: mongodb-replicaset


### PR DESCRIPTION
Update the dependencies like `minikube` that's coming with most recent K8s `v1.16` to make sure chart is working with latest Kubernetes.

This PR also switches `rabbitmq-ha` Helm chart dependency to `1.36.4` version which updates some deprecated K8s APIs https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ (Fixes #85)

```
 Error: validation failed: unable to recognize "": no matches for kind "StatefulSet" in version "apps/v1beta1"
```