### PR TITLE
Fix st2web ingress

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -37,7 +37,7 @@ spec:
     {{- end }}
     http:
       paths:
-        - path: "/*"
+        - path: "/"
           backend:
             serviceName: {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }}
             servicePort: "80"


### PR DESCRIPTION
This asterisk makes the ingress not work. It works successfully after removing it.