### PR TITLE
Fixed ingress documentation in values.yaml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -133,8 +133,6 @@ ingress:
   # Map hosts to paths
   hosts: []
   # - host: hostname.domain.tld
-  #   # NOTE: Both path and service details are optional. A working default will be used to
-  #   # automatically configure st2web for ingress.
   #   # Map paths to services
   #   paths:
   #     - path: /


### PR DESCRIPTION
The comment incorrectly mentioned that filling out the `paths` key was
optional when in fact all fields are required.