### PR TITLE
Fix failed CI builds due to e2e timeouts/resources issue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,6 +66,8 @@ jobs:
 
   # Spin up minikube K8s cluster and run Helm chart & e2e tests on it
   helm-e2e:
+    # 4CPUs & 8GB RAM CircleCI machine
+    resource_class: large
     machine:
       # Available images https://circleci.com/docs/2.0/configuration-reference/#available-machine-images
       image: ubuntu-1604:201903-01

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,8 @@ jobs:
 
   # Spin up minikube K8s cluster and run Helm chart & e2e tests on it
   helm-e2e:
-    # 4 vCPUs & 15GB RAM CircleCI machine executor
+    # 'large' 4 vCPUs & 15GB RAM CircleCI machine executor
+    # required to deploy heavy 'stackstorm-ha' Helm release with RabbitMQ, MongoDB, etcd clusters and 25+ st2 Pods.
     # https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux
     resource_class: large
     machine:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,8 @@ jobs:
 
   # Spin up minikube K8s cluster and run Helm chart & e2e tests on it
   helm-e2e:
-    # 4CPUs & 8GB RAM CircleCI machine
+    # 4 vCPUs & 15GB RAM CircleCI machine executor
+    # https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux
     resource_class: large
     machine:
       # Available images https://circleci.com/docs/2.0/configuration-reference/#available-machine-images


### PR DESCRIPTION
StackStorm-HA deployment timeouts due to high amount of resources required to provision MongoDB/RabbitMQ/etcd cluster as well as `25+` st2 pods. It all exceeds allowed 10mins timeout in CircleCI builds.

Try to use `Large` CircleCI machine type with more vCPUs & RAM: https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux