### PR TITLE
Added templating capability for st2kv from values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## In Development
-* Add ability of templating on `st2.kv`
+* Add ability of templating on `st2.keyvalue` in Helm Values (#108)
 
 ## v0.23.0
 * Add support for latest K8s version `1.16`, update e2e CI

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Add ability of templating on `st2.kv`
 
 ## v0.23.0
 * Add support for latest K8s version `1.16`, update e2e CI

--- a/templates/secrets_st2kv.yaml
+++ b/templates/secrets_st2kv.yaml
@@ -15,4 +15,4 @@ metadata:
     heritage: "{{ .Release.Service }}"
 type: Opaque
 data:
-  st2kv.yaml: {{ toYaml .Values.st2.keyvalue | b64enc | quote }}
+  st2kv.yaml: {{ tpl (toYaml .Values.st2.keyvalue ) . | b64enc | quote }}

--- a/values.yaml
+++ b/values.yaml
@@ -110,6 +110,11 @@ st2:
     #  secret: false
     #  encrypted: false
     #  value: "2.9"
+    #- name: release_name
+    #  scope: st2kv.system
+    #  secret: false
+    #  encrypted: false
+    #  value: "{{ .Release.Name }}"
   # Import a list of ST2 API Keys (https://docs.stackstorm.com/authentication.html#api-key-migration)
   apikeys:
     #- created_at: '2018-12-15T00:21:48.507388Z'


### PR DESCRIPTION
Closes #102


With this commit, a user should be able to use templating features in `st2.keyvalue`.

Example usage:
<pre>
  keyvalue:
    - name: xxx_mongo_ipv4
      scope: st2kv.system
      secret: false
      encrypted: false
      value: "<b>{{ .Release.Name }}</b>-xxx-mongodb-ha-client"
</pre>