### PR TITLE
Update ingress.yaml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Change ingress name from `<release name>-ingress` to <release name>-st2web-ingress, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
 
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-ingress{{ template "enterpriseSuffix" . }}
+  name: {{ .Release.Name }}-st2web-ingress{{ template "enterpriseSuffix" . }}
   labels:
     app: ingress
     tier: frontend

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -3,7 +3,7 @@
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
-  name: {{ .Release.Name }}-st2web-ingress{{ template "enterpriseSuffix" . }}
+  name: {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }}-ingress
   labels:
     app: ingress
     tier: frontend


### PR DESCRIPTION
Using `{{ .Release.Name }}-ingress` is not informing enough and causes a problem when using `stackstorm-ha` as a dependency for another chart. Helm creates the ingress resource as `{{ .Release.Name }}-ingress` but it's not the ingress of the current chart. This would make the ingress resource of `stackstorm-ha` more definitive.