### PR TITLE
Allow injecting of hostAliases in the actionrunner deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## In Development
 * Change ingress name from `<release name>-ingress` to <release name>-st2web-ingress, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
 * Fix st2web ingress which should have been defined as an Integer instead of a String (#111) (by @erenatas)
-* Add an option to inject hostAliases in the st2actionrunner containers
+* Add an option to inject hostAliases in the st2actionrunner containers (#114)
 
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Change ingress name from `<release name>-ingress` to <release name>-st2web-ingress, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
 * Fix st2web ingress which should have been defined as an Integer instead of a String (#111) (by @erenatas)
+* Add an option to inject hostAliases in the st2actionrunner containers
 
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -947,6 +947,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
     spec:
+      hostAliases:
+{{ toYaml .Values.st2actionrunner.hostAliases | indent 8 }}
       imagePullSecrets:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -947,8 +947,10 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.st2actionrunner.hostAliases }}
       hostAliases:
 {{ toYaml .Values.st2actionrunner.hostAliases | indent 8 }}
+      {{- end }}
       imagePullSecrets:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license

--- a/values.yaml
+++ b/values.yaml
@@ -313,6 +313,7 @@ st2actionrunner:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  hostAliases: []
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.
 # By default this process does nothing and needs to be setup in st2.conf to perform any work.

--- a/values.yaml
+++ b/values.yaml
@@ -313,7 +313,16 @@ st2actionrunner:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  # Allow the injection of hostAliases (https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/#adding-additional-entries-with-hostaliases)
+  # records in the st2actionrunner containers to handle edge case in DNS accessibility/topology
   hostAliases: []
+  # - hostnames:
+  #     - foo
+  #   ip: 1.1.1.1
+  #  - hostnames:
+  #      - bar
+  #   ip: 8.8.8.8
+
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.
 # By default this process does nothing and needs to be setup in st2.conf to perform any work.


### PR DESCRIPTION
This would allow the actionrunner to work with exotic DNS configuration
eg: you have access to some bastion host through its IP but you can't
resolve its name
The config directive is completely optional and won't impact existing
deployments