### PR TITLE
Allow usage of datastore encryption with a pregenerated key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@
 * Add an option to inject hostAliases in the st2actionrunner containers (#114)
 * Add support for Service Accounts (#117) (by @Vince-Chenal)
 
-
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)
 * Add ability of templating on `st2.keyvalue` in Helm Values (#108) (by @erenatas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Change ingress name from `<release name>-ingress` to <release name>-st2web-ingress, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
 * Fix st2web ingress which should have been defined as an Integer instead of a String (#111) (by @erenatas)
 * Add an option to inject hostAliases in the st2actionrunner containers (#114)
+* Allow injection of datastore key in cluster (#115) (by @AngryDeveloper)
 
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -37,6 +37,10 @@ data:
     {{- end }}
     port = {{ index .Values "mongodb-ha" "port" }}
     {{- end }}
+    {{- if .Values.st2.datastoreEncryption.enabled }}
+    [keyvalue]
+    encryption_key_path = {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}/encryption_key.json
+    {{- end }}
 
   # User-defined st2 config with custom settings applied on top of everything else.
   # The order of merging: st2.conf < st2.docker.conf < st2.user.conf

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -37,9 +37,9 @@ data:
     {{- end }}
     port = {{ index .Values "mongodb-ha" "port" }}
     {{- end }}
-    {{- if .Values.st2.datastoreEncryption.enabled }}
+    {{- if .Values.secrets.st2.datastore_crypto_key }}
     [keyvalue]
-    encryption_key_path = {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}/encryption_key.json
+    encryption_key_path = /etc/st2/keys/datastore_key.json
     {{- end }}
 
   # User-defined st2 config with custom settings applied on top of everything else.

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -453,9 +453,6 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-        {{- if $.Values.secrets.st2.datastore_crypto_key }}
-        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-        {{- end }}
     spec:
       {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
@@ -478,11 +475,6 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if .Values.secrets.st2.datastore_crypto_key }}
-        - name: st2-encryption-key-vol
-          mountPath: /etc/st2/keys
-          readOnly: true
-        {{- end }}
         resources:
 {{ toYaml .Values.st2rulesengine.resources | indent 10 }}
     {{- if .Values.st2rulesengine.serviceAccount.attach }}
@@ -880,7 +872,8 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") $ | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") $ | sha256sum }}
         {{- if $.Values.secrets.st2.datastore_crypto_key }}
-        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") & | sha256sum }}
+        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") $ | sha256sum }}
+        {{- end }}
         {{- if .annotations }}
 {{ toYaml .annotations | indent 8 }}
         {{- end }}
@@ -1044,6 +1037,7 @@ spec:
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         {{- if $.Values.secrets.st2.datastore_crypto_key }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.st2actionrunner.annotations }}
 {{ toYaml .Values.st2actionrunner.annotations | indent 8 }}
         {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -201,6 +201,11 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          readOnly: true
+        {{- end }}
         {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
@@ -212,6 +217,14 @@ spec:
         resources:
 {{ toYaml .Values.st2api.resources | indent 10 }}
       volumes:
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          secret:
+            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            items:
+            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
+              path: encryption_key.json
+        {{- end }}
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
@@ -447,12 +460,25 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          readOnly: true
+        {{- end }}
         resources:
 {{ toYaml .Values.st2rulesengine.resources | indent 10 }}
       volumes:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          secret:
+            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            items:
+            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
+              path: encryption_key.json
+        {{- end }}
     {{- with .Values.st2rulesengine.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -598,12 +624,25 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          readOnly: true
+        {{- end }}
         resources:
 {{ toYaml .Values.st2workflowengine.resources | indent 10 }}
       volumes:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          secret:
+            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            items:
+            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
+              path: encryption_key.json
+        {{- end }}
     {{- with .Values.st2workflowengine.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -1006,6 +1045,11 @@ spec:
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          readOnly: true
+        {{- end }}
         {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
@@ -1017,6 +1061,14 @@ spec:
         resources:
 {{ toYaml .Values.st2actionrunner.resources | indent 10 }}
       volumes:
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          secret:
+            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            items:
+            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
+              path: encryption_key.json
+        {{- end }}
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
@@ -1263,6 +1315,11 @@ spec:
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          readOnly: true
+        {{- end }}
         {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
@@ -1280,6 +1337,14 @@ spec:
             memory: "5Mi"
             cpu: "5m"
       volumes:
+        {{- if .Values.st2.datastoreEncryption.enabled }}
+        - name: st2-encryption-key-vol
+          secret:
+            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            items:
+            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
+              path: encryption_key.json
+        {{- end }}
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -201,9 +201,9 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
-          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
         {{- if .Values.st2.packs.image.repository }}
@@ -217,13 +217,13 @@ spec:
         resources:
 {{ toYaml .Values.st2api.resources | indent 10 }}
       volumes:
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
-            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
-              path: encryption_key.json
+            - key: datastore_crypto_key
+              path: datastore_key.json
         {{- end }}
         - name: st2-config-vol
           configMap:
@@ -460,9 +460,9 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
-          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
         resources:
@@ -471,13 +471,13 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            secretName: datastore_crypto_key
             items:
-            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
-              path: encryption_key.json
+            - key: datastore_crypto_key
+              path: datastore_key.json
         {{- end }}
     {{- with .Values.st2rulesengine.nodeSelector }}
       nodeSelector:
@@ -624,9 +624,9 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
-          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
         resources:
@@ -635,12 +635,12 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
-            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
+            - key: datastore_crypto_key
               path: encryption_key.json
         {{- end }}
     {{- with .Values.st2workflowengine.nodeSelector }}
@@ -923,9 +923,22 @@ spec:
           mountPath: /opt/stackstorm/virtualenvs
           readOnly: true
         {{- end }}
+        {{- if $.Values.secrets.st2.datastore_crypto_key }}
+        - name: st2-encryption-key-vol
+          mountPath: /etc/st2/keys
+          readOnly: true
+        {{- end }}
         resources:
 {{ toYaml .resources | indent 10 }}
       volumes:
+        {{- if $.Values.secrets.st2.datastore_crypto_key }}
+        - name: st2-encryption-key-vol
+          secret:
+            secretName: {{ $.Release.Name }}-st2-datastore-crypto-key
+            items:
+            - key: datastore_crypto_key
+              path: datastore_key.json
+        {{- end }}
         - name: st2-config-vol
           configMap:
             name: {{ $.Release.Name }}-st2-config
@@ -1049,9 +1062,9 @@ spec:
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
-          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
         {{- if .Values.st2.packs.image.repository }}
@@ -1065,13 +1078,13 @@ spec:
         resources:
 {{ toYaml .Values.st2actionrunner.resources | indent 10 }}
       volumes:
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
-            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
-              path: encryption_key.json
+            - key: datastore_crypto_key
+              path: datastore_key.json
         {{- end }}
         - name: st2-config-vol
           configMap:
@@ -1319,9 +1332,9 @@ spec:
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
-          mountPath: {{ .Values.st2.datastoreEncryption.encryptionKeyPath }}
+          mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
         {{- if .Values.st2.packs.image.repository }}
@@ -1341,13 +1354,13 @@ spec:
             memory: "5Mi"
             cpu: "5m"
       volumes:
-        {{- if .Values.st2.datastoreEncryption.enabled }}
+        {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: {{ .Values.st2.datastoreEncryption.secret.name }}
+            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
-            - key: {{ .Values.st2.datastoreEncryption.secret.key | default "datastore_encryption_key.json"  }}
-              path: encryption_key.json
+            - key: datastore_crypto_key
+              path: datastore_key.json
         {{- end }}
         - name: st2-config-vol
           configMap:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -650,7 +650,7 @@ spec:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
-              path: encryption_key.json
+              path: datastore_key.json
         {{- end }}
     {{- with .Values.st2workflowengine.nodeSelector }}
       nodeSelector:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -143,9 +143,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-        {{- if $.Values.secrets.st2.datastore_crypto_key }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.enterprise.enabled }}
@@ -618,9 +616,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-        {{- if $.Values.secrets.st2.datastore_crypto_key }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-        {{- end }}
     spec:
       {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
@@ -871,9 +867,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") $ | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") $ | sha256sum }}
-        {{- if $.Values.secrets.st2.datastore_crypto_key }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") $ | sha256sum }}
-        {{- end }}
         {{- if .annotations }}
 {{ toYaml .annotations | indent 8 }}
         {{- end }}
@@ -1035,9 +1029,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
-        {{- if $.Values.secrets.st2.datastore_crypto_key }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-        {{- end }}
         {{- if .Values.st2actionrunner.annotations }}
 {{ toYaml .Values.st2actionrunner.annotations | indent 8 }}
         {{- end }}
@@ -1278,9 +1270,7 @@ spec:
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
-        {{- if $.Values.secrets.st2.datastore_crypto_key }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.enterprise.enabled }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -140,6 +140,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if $.Values.secrets.st2.datastore_crypto_key }}
+        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.enterprise.enabled }}
@@ -438,6 +441,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if $.Values.secrets.st2.datastore_crypto_key }}
+        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
@@ -602,6 +608,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if $.Values.secrets.st2.datastore_crypto_key }}
+        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
@@ -843,6 +852,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") $ | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") $ | sha256sum }}
+        {{- if $.Values.secrets.st2.datastore_crypto_key }}
+        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if $.Values.enterprise.enabled }}
@@ -998,6 +1010,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
+        {{- if $.Values.secrets.st2.datastore_crypto_key }}
+        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       {{- if .Values.st2actionrunner.hostAliases }}
       hostAliases:
@@ -1229,6 +1244,9 @@ spec:
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
+        {{- if $.Values.secrets.st2.datastore_crypto_key }}
+        checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.enterprise.enabled }}

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.secrets.st2.datastore_crypto_key }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-st2-datastore-crypto-key
+  annotations:
+    description: StackStorm crypto key used to encrypt/decrypt KV records
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    support: {{ template "supportMethod" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    heritage: "{{ .Release.Service }}"
+type: Opaque
+data:
+  # Datastore key used to encrypt/decrypt record for the KV store
+  datastore_crypto_key: {{ .Values.secrets.st2.datastore_crypto_key | b64enc }}
+
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -62,6 +62,17 @@ st2:
     [api]
     allow_origin = '*'
 
+  # Optional configuration for handling a precomputed datastore encryption key
+  datastoreEncryption:
+    enabled: false
+    # Where will the key be mounted in the containers
+    encryptionKeyPath: /etc/st2/keys
+  # secret:
+  #   # The name of the secret in which the key is stored
+  #   name: st2-encryption-key
+  #   # The key containing the json formated encryption key
+  #   key: datastore_encryption_key.json
+
   # Custom pack configs and image settings.
   #
   # By default, system packs are available. However, since 'st2 pack install' cannot be run in the k8s cluster,

--- a/values.yaml
+++ b/values.yaml
@@ -62,17 +62,6 @@ st2:
     [api]
     allow_origin = '*'
 
-  # Optional configuration for handling a precomputed datastore encryption key
-  datastoreEncryption:
-    enabled: false
-    # Where will the key be mounted in the containers
-    encryptionKeyPath: /etc/st2/keys
-  # secret:
-  #   # The name of the secret in which the key is stored
-  #   name: st2-encryption-key
-  #   # The key containing the json formated encryption key
-  #   key: datastore_encryption_key.json
-
   # Custom pack configs and image settings.
   #
   # By default, system packs are available. However, since 'st2 pack install' cannot be run in the k8s cluster,
@@ -162,7 +151,7 @@ ingress:
   #     - chart-example.test
 
 ##
-## StackStorm HA Cluster Secrets. All fields are required!
+## StackStorm HA Cluster Secrets.
 ## NB! It's highly recommended to change ALL defaults!
 ##
 # TODO: Move to `secrets.yaml` when it gets implemented in Helm (https://github.com/kubernetes/helm/issues/2196) ? (#14)
@@ -204,6 +193,10 @@ secrets:
       WE8BWLQ1vBV6c7V4Q0Wp6LuTnNnvu/lvVugJW/TbrzFw6CFe5fEISmIHAMnqVz8x
       OdOJyinSM1svoBGnYfyAqINKrqCSGSKmprlMo0Ma3erI7SuojWBS
       -----END RSA PRIVATE KEY-----
+    # ST2 crypto key for the  K/V datastore.
+    # See https://docs.stackstorm.com/datastore.html#securing-secrets-admin-only for more info.
+    # Warning! Replace with your own generated key!
+    #datastore_crypto_key: {"hmacKey": {"hmacKeyString": "", "size": 256}, "size": 256, "aesKeyString": "", "mode": "CBC"}
 
 ##
 ## StackStorm HA Cluster pod settings for each individual service/component.


### PR DESCRIPTION
Closes https://github.com/StackStorm/stackstorm-ha/issues/9

This will allow the deployment to use datastore encryption if we provide
the required key through a K8S secret.

The secret's name and the key containing the effective json is configurable through values.yaml

By default the feature is disabled (and the chart behavior is unchanged).

The secret is mounted in the following deployments:

- st2api
- st2actionrunner
- st2sensorcontainers
- st2workflowengine
- ~st2rulesengine~

I might have missed some where the key is a dependency but I didn't run into any issue during my tests.