### PR TITLE
Add Service Account Management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,7 @@
 * Change ingress name from `<release name>-ingress` to <release name>-st2web-ingress, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
 * Fix st2web ingress which should have been defined as an Integer instead of a String (#111) (by @erenatas)
 * Add an option to inject hostAliases in the st2actionrunner containers (#114)
-
-## v0.25.0
-* Add support for Service Accounts (by @Vince-Chenal)
+* Add support for Service Accounts (#117) (by @Vince-Chenal)
 
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Fix st2web ingress which should have been defined as an Integer instead of a String (#111) (by @erenatas)
 * Add an option to inject hostAliases in the st2actionrunner containers (#114)
 
+## v0.25.0
+* Add support for Service Accounts (by @Vince-Chenal)
+
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)
 * Add ability of templating on `st2.keyvalue` in Helm Values (#108) (by @erenatas)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,3 +1,8 @@
+# Expand the name of the chart.
+{{- define "stackstorm-ha.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
 # Image pull secret used to access private docker.stackstorm.com Docker registry with Enterprise images
 {{- define "imagePullSecret" }}
 {{- if required "Missing context '.Values.enterprise.enabled'!" .Values.enterprise.enabled -}}
@@ -21,6 +26,13 @@ docker.stackstorm.com
 {{- else -}}
 stackstorm
 {{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the stackstorm-ha service account to use
+*/}}
+{{- define "stackstorm-ha.serviceAccountName" -}}
+{{- default .Chart.Name .Values.serviceAccount.serviceAccountName -}}
 {{- end -}}
 
 # Generate '-enterprise' suffix only when it's needed for resource names, docker images, etc

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1427,7 +1427,7 @@ spec:
 {{ toYaml .Values.st2chatops.resources | indent 10 }}
     {{- if .Values.st2chatops.serviceAccount.attach }}
         serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
-      {{- end }}
+    {{- end }}
     {{- with .Values.st2chatops.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -86,6 +86,9 @@ spec:
           readOnly: true
         resources:
 {{ toYaml .Values.st2auth.resources | indent 10 }}
+    {{- if .Values.st2auth.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -211,6 +214,9 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.st2api.resources | indent 10 }}
+    {{- if .Values.st2api.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -294,6 +300,9 @@ spec:
           subPath: st2.user.conf
         resources:
 {{ toYaml .Values.st2stream.resources | indent 10 }}
+    {{- if .Values.st2stream.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -377,6 +386,9 @@ spec:
         volumeMounts: []
         resources:
 {{ toYaml .Values.st2web.resources | indent 10 }}
+    {{- if .Values.st2web.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes: []
     {{- with .Values.st2web.nodeSelector }}
       nodeSelector:
@@ -449,6 +461,9 @@ spec:
           subPath: st2.user.conf
         resources:
 {{ toYaml .Values.st2rulesengine.resources | indent 10 }}
+    {{- if .Values.st2rulesengine.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -525,6 +540,9 @@ spec:
           subPath: st2.user.conf
         resources:
 {{ toYaml .Values.st2timersengine.resources | indent 10 }}
+    {{- if .Values.st2timersengine.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -600,6 +618,9 @@ spec:
           subPath: st2.user.conf
         resources:
 {{ toYaml .Values.st2workflowengine.resources | indent 10 }}
+    {{- if .Values.st2workflowengine.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -674,6 +695,9 @@ spec:
           subPath: st2.user.conf
         resources:
 {{ toYaml .Values.st2scheduler.resources | indent 10 }}
+    {{- if .Values.st2scheduler.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -749,6 +773,9 @@ spec:
           subPath: st2.user.conf
         resources:
 {{ toYaml .Values.st2notifier.resources | indent 10 }}
+    {{- if .Values.st2notifier.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -886,6 +913,9 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .resources | indent 10 }}
+    {{- if .serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" $ }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -1020,6 +1050,9 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.st2actionrunner.resources | indent 10 }}
+    {{- if .Values.st2actionrunner.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -1109,6 +1142,9 @@ spec:
           subPath: st2.user.conf
         resources:
 {{ toYaml .Values.st2garbagecollector.resources | indent 10 }}
+    {{- if .Values.st2garbagecollector.serviceAccount.attach }}
+      serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+    {{- end }}
       volumes:
         - name: st2-config-vol
           configMap:
@@ -1389,6 +1425,9 @@ spec:
           periodSeconds: 30
         resources:
 {{ toYaml .Values.st2chatops.resources | indent 10 }}
+    {{- if .Values.st2chatops.serviceAccount.attach }}
+        serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
+      {{- end }}
     {{- with .Values.st2chatops.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.serviceAccount.create }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "stackstorm-ha.serviceAccountName" . }}
+  {{- if .Values.serviceAccount.serviceAccountAnnotations }}
+  annotations:
+{{ toYaml .Values.serviceAccount.serviceAccountAnnotations | indent 4 }}
+  {{- end }}
+  labels:
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    app: "{{ template "stackstorm-ha.name" . }}"
+    heritage: "{{ .Release.Service }}"
+    release: "{{ .Release.Name }}"
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -54,6 +54,17 @@ enterprise:
       #    - "admin"
 
 ##
+## Service Account
+##
+serviceAccount:
+  # Whether the Chart should create the service account or not
+  create: true
+  # Used to define service account annotations
+  serviceAccountAnnotations: {}
+  # Used to override service account name
+  serviceAccountName:
+
+##
 ## StackStorm shared variables
 ##
 st2:
@@ -103,6 +114,8 @@ st2:
         affinity: {}
         nodeSelector: {}
         tolerations: []
+        serviceAccount:
+          attach: false
   # Import data into StackStorm's Key/Value datastore (https://docs.stackstorm.com/datastore.html)
   keyvalue:
     #- name: st2_version
@@ -223,6 +236,8 @@ st2web:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2auth
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
 st2auth:
@@ -233,6 +248,8 @@ st2auth:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2api
 # Multiple st2api process can be behind a load balancer in an active-active configuration.
 st2api:
@@ -243,6 +260,8 @@ st2api:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2stream
 # Multiple st2stream process can be behind a load balancer in an active-active configuration.
 st2stream:
@@ -253,6 +272,8 @@ st2stream:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2rulesengine
 # Multiple st2rulesengine processes can run in active-active with only connections to MongoDB and RabbitMQ. All these will share the TriggerInstance load and naturally pick up more work if one or more of the processes becomes unavailable.
 st2rulesengine:
@@ -263,6 +284,8 @@ st2rulesengine:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2timersengine
 # Only single replica is created via K8s Deployment as timersengine can't work in active-active mode at the moment and it relies on K8s failover/reschedule capabilities to address cases of process failure.
 st2timersengine:
@@ -272,6 +295,8 @@ st2timersengine:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2workflowengine
 # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
 st2workflowengine:
@@ -282,6 +307,8 @@ st2workflowengine:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2scheduler
 # TODO: Description TBD
 st2scheduler:
@@ -292,6 +319,8 @@ st2scheduler:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2notifier
 # st2notifier runs in active-active mode and requires for that coordination backend like Redis or Zookeeper
 st2notifier:
@@ -302,6 +331,8 @@ st2notifier:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 # https://docs.stackstorm.com/reference/ha.html#st2actionrunner
 # Multiple st2actionrunner processes can run in active-active with only connections to MongoDB and RabbitMQ. Work gets naturally
 # distributed across runners via RabbitMQ. Adding more st2actionrunner processes increases the ability of StackStorm to execute actions.
@@ -322,6 +353,8 @@ st2actionrunner:
   #  - hostnames:
   #      - bar
   #   ip: 8.8.8.8
+  serviceAccount:
+    attach: false
 
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.
@@ -335,6 +368,8 @@ st2garbagecollector:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 
 ##
 ## StackStorm ChatOps (https://docs.stackstorm.com/chatops/index.html)
@@ -367,6 +402,8 @@ st2chatops:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  serviceAccount:
+    attach: false
 
 ##
 ## MongoDB HA configuration (3rd party chart dependency)


### PR DESCRIPTION
The goal of this PR is to:
- allow creating a Service Account dedicated to st2 from the Chart
- attach it (or another external one) to the pods you want

On my side, I need this to give st2actionrunner access to AWS via a Service Account.
https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

