### PR TITLE
Allow mounting of NFS volumes instead of using st2packs for pack management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Change ingress name from `<release name>-ingress` to <release name>-st2web-ingress, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
 * Fix st2web ingress which should have been defined as an Integer instead of a String (#111) (by @erenatas)
 * Add an option to inject hostAliases in the st2actionrunner containers (#114)
+* Add an option to mount NFS volumes instead of using the `st2packs` image (#18) (by @AngryDevelopper)
 
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Change ingress name from `<release name>-ingress` to <release name>-st2web-ingress, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
 * Fix st2web ingress which should have been defined as an Integer instead of a String (#111) (by @erenatas)
 * Add an option to inject hostAliases in the st2actionrunner containers (#114)
-* Add an option to mount NFS volumes instead of using the `st2packs` image (#18) (by @AngryDevelopper)
+* Add an option to mount NFS volumes instead of using the `st2packs` image (#118) (by @AngryDevelopper)
 
 ## v0.24.0
 * Fix st2web ingress to use `/` path by default instead of `/*`, useful for nginx ingress controller (#103) (by @erenatas)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -57,3 +57,21 @@ stackstorm
 {{ $mongo_fullname }}-{{ $index0 }}.{{ $mongo_fullname }}{{ if ne $index1 $replicas }},{{ end }}
   {{- end -}}
 {{- end -}}
+
+{{- define "packs-volumes" -}}
+{{- if .Values.st2.packs.image.repository }}
+- name: st2-packs-vol
+  emptyDir: {}
+- name: st2-virtualenvs-vol
+  emptyDir: {}
+{{- else if .Values.st2.packs.nfs.server }}
+- name: st2-packs-vol
+  nfs:
+    server: {{ .Values.st2.packs.nfs.server }}
+    path: {{ .Values.st2.packs.nfs.packsPath }}
+- name: st2-virtualenvs-vol
+  nfs:
+    server: {{ .Values.st2.packs.nfs.server }}
+    path: {{ .Values.st2.packs.nfs.virtualenvsPath }}
+{{- end }}
+{{- end -}}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -201,17 +201,18 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if (.Values.st2.packs.image.repository) or (.Values.st2.packs.nfs.server) }}
+        {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
-          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
-          {{- end }}
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs
-          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
-          {{- end }}
+        {{- else if .Values.st2.packs.nfs.server }}
+        - name: st2-packs-vol
+          mountPath: /opt/stackstorm/packs
+        - name: st2-virtualenvs-vol
+          mountPath: /opt/stackstorm/virtualenvs
         {{- end }}
         resources:
 {{ toYaml .Values.st2api.resources | indent 10 }}
@@ -875,17 +876,18 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if ($.Values.st2.packs.image.repository) or ($.Values.st2.packs.nfs.server) }}
+        {{- if $.Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
-          {{- if $.Values.st2.packs.image.repository }}
           readOnly: true
-          {{- end }}
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs
-          {{- if $.Values.st2.packs.image.repository }}
           readOnly: true
-          {{- end }}
+        {{- else if $.Values.st2.packs.nfs.server }}
+        - name: st2-packs-vol
+          mountPath: /opt/stackstorm/packs
+        - name: st2-virtualenvs-vol
+          mountPath: /opt/stackstorm/virtualenvs
         {{- end }}
         resources:
 {{ toYaml .resources | indent 10 }}
@@ -1008,17 +1010,18 @@ spec:
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
-        {{- if (.Values.st2.packs.image.repository) or (.Values.st2.packs.nfs.server) }}
+        {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
-          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
-          {{- end }}
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs
-          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
-          {{- end }}
+        {{- else if .Values.st2.packs.nfs.server }}
+        - name: st2-packs-vol
+          mountPath: /opt/stackstorm/packs
+        - name: st2-virtualenvs-vol
+          mountPath: /opt/stackstorm/virtualenvs
         {{- end }}
         resources:
 {{ toYaml .Values.st2actionrunner.resources | indent 10 }}
@@ -1264,17 +1267,18 @@ spec:
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
-        {{- if (.Values.st2.packs.image.repository) or (.Values.st2.packs.nfs.server) }}
+        {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
-          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
-          {{- end }}
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs
-          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
-          {{- end }}
+        {{- else if .Values.st2.packs.nfs.server }}
+        - name: st2-packs-vol
+          mountPath: /opt/stackstorm/packs
+        - name: st2-virtualenvs-vol
+          mountPath: /opt/stackstorm/virtualenvs
         {{- end }}
         command:
           - 'bash'

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -201,13 +201,17 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if .Values.st2.packs.image.repository }}
+        {{- if (.Values.st2.packs.image.repository) or (.Values.st2.packs.nfs.server) }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
+          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
+          {{- end }}
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs
+          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
+          {{- end }}
         {{- end }}
         resources:
 {{ toYaml .Values.st2api.resources | indent 10 }}
@@ -215,12 +219,7 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
-        {{- end }}
+        {{- include "packs-volumes" . | indent 8 }}
     {{- with .Values.st2api.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -876,13 +875,17 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if $.Values.st2.packs.image.repository }}
+        {{- if ($.Values.st2.packs.image.repository) or ($.Values.st2.packs.nfs.server) }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
+          {{- if $.Values.st2.packs.image.repository }}
           readOnly: true
+          {{- end }}
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs
+          {{- if $.Values.st2.packs.image.repository }}
           readOnly: true
+          {{- end }}
         {{- end }}
         resources:
 {{ toYaml .resources | indent 10 }}
@@ -890,13 +893,8 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ $.Release.Name }}-st2-config
-        {{- if $.Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
-        {{- end }}
-    {{- with .nodeSelector }}
+        {{- include "packs-volumes" $ | indent 8}}
+        {{- with .nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
     {{- end }}
@@ -1010,13 +1008,17 @@ spec:
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
-        {{- if .Values.st2.packs.image.repository }}
+        {{- if (.Values.st2.packs.image.repository) or (.Values.st2.packs.nfs.server) }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
+          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
+          {{- end }}
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs
+          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
+          {{- end }}
         {{- end }}
         resources:
 {{ toYaml .Values.st2actionrunner.resources | indent 10 }}
@@ -1032,12 +1034,7 @@ spec:
               path: stanley_rsa
               # 0400 file permission
               mode: 256
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
-        {{- end }}
+        {{- include "packs-volumes" . | indent 8 }}
     {{- with .Values.st2actionrunner.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}
@@ -1267,13 +1264,17 @@ spec:
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
-        {{- if .Values.st2.packs.image.repository }}
+        {{- if (.Values.st2.packs.image.repository) or (.Values.st2.packs.nfs.server) }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
+          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
+          {{- end }}
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs
+          {{- if .Values.st2.packs.image.repository }}
           readOnly: true
+          {{- end }}
         {{- end }}
         command:
           - 'bash'
@@ -1312,12 +1313,7 @@ spec:
               path: stanley_rsa
               # 0400 file permission
               mode: 256
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
-        {{- end }}
+        {{- include "packs-volumes" . | indent 8 }}
 
 {{ if .Values.st2chatops.enabled -}}
 ---

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -323,8 +323,8 @@ spec:
       {{- if .Values.st2.packs.image.pullSecret }}
       - name: {{ .Values.st2.packs.image.pullSecret }}
       {{- end }}
-      {{- if .Values.st2.packs.image.repository }}
       initContainers:
+      {{- if .Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
@@ -341,6 +341,7 @@ spec:
           - |
             /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      {{ end }}
       # System packs
       - name: st2-system-packs
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -354,7 +355,6 @@ spec:
           - |
             /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      {{ end }}
       containers:
       - name: st2-register-content
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -377,9 +377,16 @@ spec:
           mountPath: /opt/stackstorm/configs/
         {{- if .Values.st2.packs.image.repository }}
         - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs/
+          mountPath: /opt/stackstorm/packs
+          readOnly: true
         - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs/
+          mountPath: /opt/stackstorm/virtualenvs
+          readOnly: true
+        {{- else if .Values.st2.packs.nfs.server }}
+        - name: st2-packs-vol
+          mountPath: /opt/stackstorm/packs
+        - name: st2-virtualenvs-vol
+          mountPath: /opt/stackstorm/virtualenvs
         {{- end }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
@@ -390,10 +397,5 @@ spec:
         - name: st2-pack-configs-vol
           configMap:
             name: {{ .Release.Name }}-st2-pack-configs
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
-        {{- end }}
+        {{- include "packs-volumes" . | indent 8 }}
       restartPolicy: OnFailure

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -342,6 +342,7 @@ spec:
             /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       {{ end }}
+      {{- if (.Values.st2.packs.image.repository) or (.Values.st2.packs.nfs.server) }}
       # System packs
       - name: st2-system-packs
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -355,6 +356,7 @@ spec:
           - |
             /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      {{ end }}
       containers:
       - name: st2-register-content
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -342,7 +342,6 @@ spec:
             /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
       {{ end }}
-      {{- if (.Values.st2.packs.image.repository) or (.Values.st2.packs.nfs.server) }}
       # System packs
       - name: st2-system-packs
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -356,7 +355,6 @@ spec:
           - |
             /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
             /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      {{ end }}
       containers:
       - name: st2-register-content
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -282,7 +282,6 @@ spec:
           secret:
             secretName: {{ .Release.Name }}-st2-kv
       restartPolicy: OnFailure
-{{- if .Values.st2.packs.image.repository }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -398,4 +397,3 @@ spec:
           emptyDir: {}
         {{- end }}
       restartPolicy: OnFailure
-{{- end }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -282,7 +282,7 @@ spec:
           secret:
             secretName: {{ .Release.Name }}-st2-kv
       restartPolicy: OnFailure
-
+{{- if .Values.st2.packs.image.repository }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -398,3 +398,4 @@ spec:
           emptyDir: {}
         {{- end }}
       restartPolicy: OnFailure
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -86,6 +86,18 @@ st2:
       # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry behind the auth
       #pullSecret: st2packs-auth
 
+    # Custom packs and virtualenvs can be mounted using NFS.
+    # Disclaimer: if you chose to use an NFS mount, be advised that the responsibility of installing and registering the
+    # packs is deferred to you.
+    # If both st2.packs.image.repository and st2.packs.nfs.server are set, the st2packs image will be used
+    nfs:
+      # Uncommend the following block to enabled NFS mounting of the packs
+      #server: 0.0.0.0
+      # Required. This should point to a directory containing all the packs folders
+      virtualenvsPath: /var/nfsshare/packs
+      # Required. This should point to an empty directoy, or a directory containing pre built venvs for the packs
+      packsPath: /var/nfsshare/virtualenvs
+
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.
     # Each sensor node needs to be provided with proper partition information to share work with other sensor

--- a/values.yaml
+++ b/values.yaml
@@ -94,9 +94,9 @@ st2:
       # Uncommend the following block to enabled NFS mounting of the packs
       #server: 0.0.0.0
       # Required. This should point to a directory containing all the packs folders
-      virtualenvsPath: /var/nfsshare/packs
+      virtualenvsPath: /var/nfsshare/virtualenvs
       # Required. This should point to an empty directoy, or a directory containing pre built venvs for the packs
-      packsPath: /var/nfsshare/virtualenvs
+      packsPath: /var/nfsshare/packs
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.


### PR DESCRIPTION
This should close #18

This will allow the end users to mount NFS volumes to manage their custom packs. To be noted: when using an NFS mount, the lifecycle management of the packs (installing/updating/registering) is deferred back to the stackstorm administrators.
One way to do it would be to trigger packs installation and/or registration through the API using
https://api.stackstorm.com/api/v1/packs/#/packs_controller.install.post
https://api.stackstorm.com/api/v1/packs/#/packs_controller.register.post
or directly through the st2client pod.

The st2packs method is of course still available. If both `st2.packs.image.repository` and `st2.packs.nfs.server` are set, the st2packs image will be used.