### PR TITLE
Prepare for Helm chart v0.25.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Changelog
 
 ## In Development
-* Change ingress name from `<release name>-ingress` to <release name>-st2web-ingress, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
+
+
+## v0.25.0
+* Change ingress name from `<release name>-ingress` to `<release name>-st2web-ingress`, useful when using `stackstorm-ha` as a requirement for another chart. (#112) (by @erenatas)
 * Fix st2web ingress which should have been defined as an Integer instead of a String (#111) (by @erenatas)
 * Add an option to inject hostAliases in the st2actionrunner containers (#114)
 * Add support for Service Accounts (#117) (by @Vince-Chenal)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.2dev
 name: stackstorm-ha
-version: 0.24.0
+version: 0.25.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009


### PR DESCRIPTION
Release `0.25.0` version of the Helm chart as we had enough new changes and fixes in.

Thanks @AngryDeveloper @erenatas @Vince-Chenal for your contributions!