### PR TITLE
Switch to st2 3.3dev with py3, Ubuntu Bionic 18.04 and MongoDB 4 (Chart v0.30.0)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ orbs:
   # Pins Helm to v2.x
   # TODO: Consider upgrading Helm to v3.0 (https://github.com/StackStorm/stackstorm-ha/issues/98)
   # https://circleci.com/orbs/registry/orb/circleci/helm
-  helm: circleci/helm@0.2.0
+  helm: circleci/helm@0.2.3
   # https://circleci.com/orbs/registry/orb/ccpgames/minikube
   minikube: ccpgames/minikube@0.0.1
 
@@ -17,7 +17,7 @@ jobs:
     working_directory: ~/stackstorm-ha
     docker:
       # Pin Helm to v2.x, see https://github.com/StackStorm/stackstorm-ha/issues/98
-      - image: lachlanevenson/k8s-helm:v2.16.1
+      - image: lachlanevenson/k8s-helm:v2.16.7
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,8 +80,15 @@ jobs:
           # https://github.com/kubernetes/minikube/releases
           version: v1.10.1
       - run:
+          name: Install dependencies
+          command: |
+            sudo apt -y update
+            # K8s 1.18 requires conntrack
+            # See: https://github.com/kubernetes/minikube/issues/7179
+            sudo apt -y install conntrack
+      - run:
           name: Create new K8s cluster
-          command: sudo -E minikube start --vm-driver=none --cpus $(nproc) --memory 4096
+          command: sudo -E minikube start --vm-driver=none
           environment:
             CHANGE_MINIKUBE_NONE_USER: true
       - helm/install-helm-on-cluster

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,7 @@ jobs:
       - kubernetes/install
       - minikube/minikube-install:
           # https://github.com/kubernetes/minikube/releases
-          version: v1.5.2
+          version: v1.10.1
       - run:
           name: Create new K8s cluster
           command: sudo -E minikube start --vm-driver=none --cpus $(nproc) --memory 4096

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,10 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            sudo apt -y update
+            sudo apt update || true
             # K8s 1.18 requires conntrack
             # See: https://github.com/kubernetes/minikube/issues/7179
-            sudo apt -y install conntrack
+            sudo apt install -y conntrack
       - run:
           name: Create new K8s cluster
           command: sudo -E minikube start --vm-driver=none

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 # Add additional CircleCI Orbs dependencies
 orbs:
   # https://circleci.com/orbs/registry/orb/circleci/kubernetes
-  kubernetes: circleci/kubernetes@0.10.1
+  kubernetes: circleci/kubernetes@0.11.0
   # Pins Helm to v2.x
   # TODO: Consider upgrading Helm to v3.0 (https://github.com/StackStorm/stackstorm-ha/issues/98)
   # https://circleci.com/orbs/registry/orb/circleci/helm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 
 ## v0.30.0
 * Pin st2 version to `v3.3dev` as a new latest development version (#129)
-* Switch from `py2` `Ubuntu Xenial` to `py3` `Ubuntu Bionic` as a base StackStorm OS (StackStorm/st2-dockerfiles#16, #129)
+* Migrate from `py2` `Ubuntu Xenial` to `py3` `Ubuntu Bionic` as a base StackStorm OS (StackStorm/st2-dockerfiles#16, #129)
+* Switch from MongoDB `3.4` to `4.0` for the mongodb-ha Helm chart (#129)
 
 ## v0.27.0
 * Added support to toggle etcd-operator as a coordination backend (#127) (by @rrahman-nv)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Pin st2 version to `v3.3dev` as a new latest development version (#129)
 * Migrate from `py2` `Ubuntu Xenial` to `py3` `Ubuntu Bionic` as a base StackStorm OS (StackStorm/st2-dockerfiles#16, #129)
 * Switch from MongoDB `3.4` to `4.0` for the mongodb-ha Helm chart (#129)
+* Update `etcd-operator` 3rd party chart from `0.10.0` to `0.10.3` (#129)
 
 ## v0.27.0
 * Added support to toggle etcd-operator as a coordination backend (#127) (by @rrahman-nv)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 * Switch from MongoDB `3.4` to `4.0` for the mongodb-ha Helm chart (#129)
 * Update `etcd-operator` 3rd party chart from `0.10.0` to latest `0.10.3` (#129)
 * Update `rabbitmq-ha` 3rd party chart from `1.36.4` to `1.44.1` (#129)
-
+* Update `mongodb-replicaset` 3rd party chart from `3.9.6` to `3.14.0` (#129)
 
 ## v0.27.0
 * Added support to toggle etcd-operator as a coordination backend (#127) (by @rrahman-nv)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@
 * Pin st2 version to `v3.3dev` as a new latest development version (#129)
 * Migrate from `py2` `Ubuntu Xenial` to `py3` `Ubuntu Bionic` as a base StackStorm OS (StackStorm/st2-dockerfiles#16, #129)
 * Switch from MongoDB `3.4` to `4.0` for the mongodb-ha Helm chart (#129)
-* Update `etcd-operator` 3rd party chart from `0.10.0` to `0.10.3` (#129)
+* Update `etcd-operator` 3rd party chart from `0.10.0` to latest `0.10.3` (#129)
+* Update `rabbitmq-ha` 3rd party chart from `1.36.4` to latest `1.44.4` (#129)
+
 
 ## v0.27.0
 * Added support to toggle etcd-operator as a coordination backend (#127) (by @rrahman-nv)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 * Migrate from `py2` `Ubuntu Xenial` to `py3` `Ubuntu Bionic` as a base StackStorm OS (StackStorm/st2-dockerfiles#16, #129)
 * Switch from MongoDB `3.4` to `4.0` for the mongodb-ha Helm chart (#129)
 * Update `etcd-operator` 3rd party chart from `0.10.0` to latest `0.10.3` (#129)
-* Update `rabbitmq-ha` 3rd party chart from `1.36.4` to latest `1.44.4` (#129)
+* Update `rabbitmq-ha` 3rd party chart from `1.36.4` to `1.44.1` (#129)
 
 
 ## v0.27.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## In Development
 
 
+## v0.30.0
+* Pin st2 version to `v3.3dev` as a new latest development version (#129)
+* Switch from `py2` `Ubuntu Xenial` to `py3` `Ubuntu Bionic` as a base StackStorm OS (StackStorm/st2-dockerfiles#16, #129)
+
 ## v0.27.0
 * Added support to toggle etcd-operator as a coordination backend (#127) (by @rrahman-nv)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ## In Development
 
-
 ## v0.30.0
 * Pin st2 version to `v3.3dev` as a new latest development version (#129)
 * Migrate from `py2` `Ubuntu Xenial` to `py3` `Ubuntu Bionic` as a base StackStorm OS (StackStorm/st2-dockerfiles#16, #129)
@@ -10,6 +9,7 @@
 * Update `etcd-operator` 3rd party chart from `0.10.0` to latest `0.10.3` (#129)
 * Update `rabbitmq-ha` 3rd party chart from `1.36.4` to `1.44.1` (#129)
 * Update `mongodb-replicaset` 3rd party chart from `3.9.6` to `3.14.0` (#129)
+* Update CI infrastructure env, run tests on updated Helm `v2.16.7`, latest minikube `v1.10.1` and K8s `1.18` (#129)
 
 ## v0.27.0
 * Added support to toggle etcd-operator as a coordination backend (#127) (by @rrahman-nv)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
-appVersion: 3.2dev
+appVersion: 3.3dev
 name: stackstorm-ha
 version: 0.27.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.3dev
 name: stackstorm-ha
-version: 0.27.0
+version: 0.30.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: rabbitmq-ha
-    version: 1.44.4
+    version: 1.44.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq-ha.enabled
   - name: mongodb-replicaset

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: rabbitmq-ha
-    version: 1.36.4
+    version: 1.44.4
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq-ha.enabled
   - name: mongodb-replicaset

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -13,7 +13,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: external-dns.enabled
   - name: etcd-operator
-    version: 0.10.0
+    version: 0.10.3
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: etcd-operator.enabled
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq-ha.enabled
   - name: mongodb-replicaset
-    version: 3.9.6
+    version: 3.14.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     alias: mongodb-ha
     condition: mongodb-ha.enabled

--- a/tests/st2tests.sh
+++ b/tests/st2tests.sh
@@ -7,9 +7,9 @@ load "${BATS_HELPERS_DIR}/bats-file/load.bash"
 @test 'st2 version deployed and python env are as expected' {
   run st2 --version
   assert_success
-  # st2 3.1dev (7079635), on Python 2.7.12
+  # st2 3.3dev (9ea417346), on Python 3.6.9
   assert_line --partial "st2 ${ST2_VERSION}"
-  assert_line --partial 'on Python 2.7.12'
+  assert_line --partial 'on Python 3.6.9'
 }
 
 @test 'ST2_AUTH_URL service endpoint is accessible and working' {

--- a/values.yaml
+++ b/values.yaml
@@ -419,8 +419,8 @@ mongodb-ha:
   # Specify your external [database] connection parameters under st2.config
   enabled: true
   image:
-    # StackStorm currently supports maximum MongoDB v3.4
-    tag: 3.4
+    # StackStorm currently supports maximum MongoDB v4.0
+    tag: "4.0"
   auth:
     enabled: true
     # NB! It's highly recommended to change ALL defaults!


### PR DESCRIPTION
Following the https://github.com/StackStorm/st2-dockerfiles/pull/16 Dockerfiles, we switch from `Ubuntu:xenial` to `Ubuntu:bionic` for the K8s Dockerfiles in the upcoming `v0.30.0` Helm chart version release.

- Chart `v0.28.0` uses `3.2dev` Dockerfiles on old `Ubuntu Xenial` with `py2` and `MongoDB 3.4`
- Chart `v0.30.0` will use new `3.3dev` Dokerfiles on new `Ubuntu Bionic` with `py3` and `MongoDB 4` #97 

And while the Helm chart is in `Beta` state and breaking changes are expected, this will provide at least some migration path for existing users.

This means StackStorm installation in K8s HA will be based on python 3 from this point.
