### PR TITLE
Downgrade mongodb-replicaset chart to 3.12.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     working_directory: ~/stackstorm-ha
     docker:
       # Pin Helm to v2.x, see https://github.com/StackStorm/stackstorm-ha/issues/98
-      - image: lachlanevenson/k8s-helm:v2.16.7
+      - image: lachlanevenson/k8s-helm:v2.16.9
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,9 @@
 # Changelog
 
-## In Development
-* Allow injection of datastore key in cluster (#115) (by @AngryDeveloper)
-
 ## v0.31.0
 
 * Makes the chart compatible with Helm versions >= `2.16.8` by downgrading `mongodb-replicaset` from `3.14.0` to `3.12.0` (#137) (by @AbhyudayaSharma)
+* Allow injection of datastore key in cluster (#115) (by @AngryDeveloper)
 
 ## v0.30.0
 * Pin st2 version to `v3.3dev` as a new latest development version (#129)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 
 ## v0.31.0
-
-* Makes the chart compatible with Helm versions >= `2.16.8` by downgrading `mongodb-replicaset` from `3.14.0` to `3.12.0` (#137) (by @AbhyudayaSharma)
+* Fix chart compatibility with Helm versions >= `2.16.8` by downgrading `mongodb-replicaset` from `3.14.0` to `3.12.0` (#137) (by @AbhyudayaSharma)
 * Allow injection of datastore key in cluster (#115) (by @AngryDeveloper)
 
 ## v0.30.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## In Development
 * Allow injection of datastore key in cluster (#115) (by @AngryDeveloper)
 
+## v0.31.0
+
+* Makes the chart compatible with Helm versions >= `2.16.8` by downgrading `mongodb-replicaset` from `3.14.0` to `3.12.0` (#137) (by @AbhyudayaSharma)
+
 ## v0.30.0
 * Pin st2 version to `v3.3dev` as a new latest development version (#129)
 * Migrate from `py2` `Ubuntu Xenial` to `py3` `Ubuntu Bionic` as a base StackStorm OS (StackStorm/st2-dockerfiles#16, #129)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.3dev
 name: stackstorm-ha
-version: 0.30.0
+version: 0.31.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq-ha.enabled
   - name: mongodb-replicaset
-    version: 3.14.0
+    version: 3.12.0
     repository: https://kubernetes-charts.storage.googleapis.com/
     alias: mongodb-ha
     condition: mongodb-ha.enabled


### PR DESCRIPTION
* Downgrades mongodb-replicaset to 3.12.0
* Upgrades helm to 2.16.9 in CircleCI

Verified that `helm lint` succeeds with helm 2.16.9.

Closes #136 

@armab 