### PR TITLE
Use the right apiVersion for Ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Fix a bug when datastore encrypted keys didn't work in scheduled rules. datastore_crypto_key is now shared with the ``st2scheduler`` pods (#148) (by @rahulshinde26)
+* Move the apiVersion `extensions/v1beta1` to `networking.k8s.io/v1beta1` for ingress (#149) (by @jb-abbadie)
 
 ## v0.31.0
 * Fix chart compatibility with Helm versions >= `2.16.8` by downgrading `mongodb-replicaset` from `3.14.0` to `3.12.0` (#137) (by @AbhyudayaSharma)

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled }}
 ---
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ .Release.Name }}-st2web{{ template "enterpriseSuffix" . }}-ingress


### PR DESCRIPTION

`extensions/v1beta1` is deprecated starting in k8s 1.16

source : https://v1-16.docs.kubernetes.io/docs/setup/release/notes/