### PR TITLE
Change NOTES template for using ST2 CLI to include namespace argument in 'kubectl exec' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Fix a bug when datastore encrypted keys didn't work in scheduled rules. datastore_crypto_key is now shared with the ``st2scheduler`` pods (#148) (by @rahulshinde26)
+* Change NOTES template for using ST2 CLI to include namespace argument in 'kubectl exec' command (#150) (by @rahulshinde26)
 
 ## v0.31.0
 * Fix chart compatibility with Helm versions >= `2.16.8` by downgrading `mongodb-replicaset` from `3.14.0` to `3.12.0` (#137) (by @AbhyudayaSharma)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+## In Development
+* Fix a bug when datastore encrypted keys didn't work in scheduled rules. datastore_crypto_key is now shared with the ``st2scheduler`` pods (#148) (by @rahulshinde26)
+
 ## v0.31.0
 * Fix chart compatibility with Helm versions >= `2.16.8` by downgrading `mongodb-replicaset` from `3.14.0` to `3.12.0` (#137) (by @AbhyudayaSharma)
 * Allow injection of datastore key in cluster (#115) (by @AngryDeveloper)
-* Allow using encrypted keys from datastore as action paramters while creating rules by mounting datastore_crypto_key for st2schedular (#148) (by @rahulshinde26)
 
 ## v0.30.0
 * Pin st2 version to `v3.3dev` as a new latest development version (#129)

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -45,7 +45,7 @@ password: {{ .Values.secrets.st2.password }}
 
 3. Use st2 CLI:
 export ST2CLIENT=$(kubectl get --namespace {{ .Release.Namespace }} pod -l app=st2client,release={{ .Release.Name }} -o jsonpath="{.items[0].metadata.name}")
-kubectl exec -it ${ST2CLIENT} -- st2 --version
+kubectl exec -it ${ST2CLIENT} --namespace {{ .Release.Namespace }} -- st2 --version
 
 -----------------------------------------------------
 Thanks for trying StackStorm!


### PR DESCRIPTION
Fixes #151 

When StackStorm is deployed in namespace other than 'Default', sample commands shown after 'helm install/upgrade' or 'helm status' to use ST2 CLI does not work.

![image](https://user-images.githubusercontent.com/7744662/90243421-7df04300-de4c-11ea-998f-193db3786472.png)
