### PR TITLE
Prepare changes for the v0.32.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## In Development
+
+
+## v0.32.0
 * Fix a bug when datastore encrypted keys didn't work in scheduled rules. datastore_crypto_key is now shared with the ``st2scheduler`` pods (#148) (by @rahulshinde26)
 * Change NOTES.txt template for using ST2 CLI to include namespace argument in 'kubectl exec' command (#150) (by @rahulshinde26)
 * Move the apiVersion `extensions/v1beta1` to `networking.k8s.io/v1beta1` for ingress (#149) (by @jb-abbadie)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.3dev
 name: stackstorm-ha
-version: 0.31.0
+version: 0.32.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/#product
 icon: https://avatars1.githubusercontent.com/u/4969009


### PR DESCRIPTION
Release the most recent changes as `v0.32.0`:

*   Fix a bug when datastore encrypted keys didn't work in scheduled rules. datastore_crypto_key is now shared with the st2scheduler pods (#148) (by @rahulshinde26)
*   Change NOTES.txt template for using ST2 CLI to include namespace argument in 'kubectl exec' command (#150) (by @rahulshinde26)
*   Move the apiVersion extensions/v1beta1 to networking.k8s.io/v1beta1 for ingress (#149) (by @jb-abbadie)
