### PR TITLE
Release v0.40.0: Switch chart to latest st2 3.4dev version, disable Enterprise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,26 +27,17 @@ jobs:
             helm init --client-only
             helm dependency update
       - run:
-          name: Helm Lint Check (Community)
+          name: Helm Lint Check
           command: helm lint
-      - run:
-          name: Helm Lint Check (Enterprise)
-          command: helm lint --set enterprise.enabled=true --set enterprise.license=123asd456fake
       - run:
           name: Helm template
           command: |
-            mkdir -p enterprise community
+            mkdir -p community
             helm template --output-dir community .
-            helm template --output-dir enterprise --set enterprise.enabled=true --set enterprise.license=123asd456fake .
       - persist_to_workspace:
           root: ~/stackstorm-ha/
           paths:
             - community
-            - enterprise
-            # TODO: Fill an issue in https://github.com/garethr/kubeval
-            # 'charts' contains 3rd party templates which doesn't validate against schema due to minor 'object != null' API validation issues
-            # See: https://circleci.com/gh/StackStorm/stackstorm-enterprise-ha/18
-            #- charts
 
   # Run Kubernetes lint checks
   k8s-lint:
@@ -56,13 +47,9 @@ jobs:
       - attach_workspace:
           at: .
       - run:
-          name: K8s Kubeval Lint Check (Community)
+          name: K8s Kubeval Lint Check
           command: kubeval $(find . -type f)
           working_directory: community/stackstorm-ha/templates/
-      - run:
-          name: K8s Kubeval Lint Check (Enterprise)
-          command: kubeval $(find . -type f)
-          working_directory: enterprise/stackstorm-ha/templates/
 
   # Spin up minikube K8s cluster and run Helm chart & e2e tests on it
   helm-e2e:
@@ -96,24 +83,14 @@ jobs:
           name: Update stackstorm-ha chart dependencies
           command: helm dependency update
       - run:
-          name: Helm install stackstorm-ha chart (Community)
+          name: Helm install stackstorm-ha chart
           command: helm install --timeout 600 --debug --wait --name stackstorm-ha .
       - run:
-          name: Helm test (Community)
+          name: Helm test
           command: helm test stackstorm-ha --parallel --cleanup
       - run:
           when: always
-          name: Show created K8s resources (Community)
-          command: kubectl get all
-      - run:
-          name: Helm upgrade stackstorm-ha (Community -> Enterprise)
-          command: helm upgrade --wait stackstorm-ha . --set enterprise.enabled=true --set enterprise.license=${EWC_LICENSE}
-      - run:
-          name: Helm test (Enterprise)
-          command: helm test stackstorm-ha --parallel
-      - run:
-          when: always
-          name: Show created K8s resources (Enterprise)
+          name: Show created K8s resources
           command: kubectl get all
 
 workflows:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 ## In Development
+
+
+## v0.40.0
+* Switch st2 version to `v3.4dev` as a new latest development version (#157)
+* Disable Enterprise testing in CI (#157)
 * Change pullPolicy to "IfNotPresent", as Docker-Hub Ratelimits now (#159) (by @moonrail)
 * Update `rabbitmq-ha` 3rd party chart from `1.44.1` to `1.46.1` (#158) (by @moonrail)
 * Enable `rabbitmqErlangCookie` for `rabbitmq-ha` by default, to ensure cluster-redeployments do not fail (#158) (by @moonrail)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.4dev
 name: stackstorm-ha
-version: 0.32.0
+version: 0.40.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/
-icon: https://avatars1.githubusercontent.com/u/4969009
+icon: https://landscape.cncf.io/logos/stack-storm.svg
 source:
   - https://github.com/stackstorm/stackstorm-ha
 keywords:
@@ -21,9 +21,8 @@ keywords:
   - HA
 maintainers:
   - name: Eugen Cusmaunsa
+    email: armab@stackstorm.com
     url: https://github.com/armab
-  - name: Warren Van Winckel
-    url: https://github.com/warrenvw
 details:
   This Helm chart is a fully installable app that codifies StackStorm cluster deployment optimized for HA and K8s environment.
   RabbitMQ-HA, MongoDB-HA clusters and coordination backend st2 relies on will be deployed as 3rd party chart dependencies.

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
-appVersion: 3.3dev
+appVersion: 3.4dev
 name: stackstorm-ha
 version: 0.32.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
-home: https://stackstorm.com/#product
+home: https://stackstorm.com/
 icon: https://avatars1.githubusercontent.com/u/4969009
 source:
   - https://github.com/stackstorm/stackstorm-ha
@@ -12,17 +12,19 @@ keywords:
   - st2
   - stackstorm
   - devops
+  - SRE
+  - automation
   - chatops
   - event-driven
   - auto-remediation
   - IFTTT
   - HA
 maintainers:
-  - name: Eugen C.
+  - name: Eugen Cusmaunsa
     url: https://github.com/armab
   - name: Warren Van Winckel
     url: https://github.com/warrenvw
 details:
-  This Helm chart is a fully installable app that codifies StackStorm cluster optimized for HA and K8s environment.
-  By default FOSS community version of st2 will be installed. Enterprise version can be enabled as an option.
-  For configuration details check 'values.yaml'.
+  This Helm chart is a fully installable app that codifies StackStorm cluster deployment optimized for HA and K8s environment.
+  RabbitMQ-HA, MongoDB-HA clusters and coordination backend st2 relies on will be deployed as 3rd party chart dependencies.
+  For configuration details please check default values.yaml and README.

--- a/README.md
+++ b/README.md
@@ -33,17 +33,6 @@ Once you make any changes to values, upgrade the cluster:
 helm upgrade <release-name> .
 ```
 
-### Enterprise (Optional)
-By default, StackStorm Community FOSS version is configured via Helm chart. If you want to install [StackStorm Enterprise (EWC)](https://docs.stackstorm.com/install/ewc_ha.html), run:
-```
-helm install --set enterprise.enabled=true --set enterprise.license=<ST2_LICENSE_KEY> .
-```
-It will pull enterprise images from private Docker registry as well as allows configuring features like RBAC and LDAP.
-See Helm `values.yaml`, `enterprise` section for configuration examples.
-
-> Don't have StackStorm Enterprise License?<br>
-> 90-day free trial can be requested at https://stackstorm.com/#product
-
 ## Configuration
 
 The default configuration values for this chart are described in `values.yaml`.

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -49,8 +49,6 @@ kubectl exec -it ${ST2CLIENT} --namespace {{ .Release.Namespace }} -- st2 --vers
 
 -----------------------------------------------------
 Thanks for trying StackStorm!
-{{- if .Values.enterprise.enabled }}
-Need help? Enterprise support: support@stackstorm.com
-{{- else }}
-Enterprise: https://stackstorm.com/#product
-{{- end }}
+Need help?
+* Forum: https://forum.stackstorm.com/
+* Slack: https://stackstorm.com/#community


### PR DESCRIPTION
> First step of the https://github.com/StackStorm/stackstorm-ha/issues/134

Following the 3.3.0 release https://stackstorm.com/2020/10/22/stackstorm-v3-3-0-released/, switch chart to the latest st2 `3.4dev` version. In this release Extreme stopped building and distributing the EWC packages and so we have to drop/disable the Enterprise flag from the Helm chart.

In next StackStorm/st2 core releases the expectations from @StackStorm/maintainers are to integrate RBAC, LDAP into the main OSS build. Once that happens, previously enterprise functionality will work natively.