### PR TITLE
Updated RabbitMQ-Chart to 1.46.1 & improved Reboot-Resilience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## In Development
 * Change pullPolicy to "IfNotPresent", as Docker-Hub Ratelimits now (#159) (by @moonrail)
-
+* Update `rabbitmq-ha` 3rd party chart from `1.44.1` to `1.46.1` (#158) (by @moonrail)
+* Enable `rabbitmqErlangCookie` for `rabbitmq-ha` by default, to ensure cluster-redeployments do not fail (#158) (by @moonrail)
+* Add `forceBoot` for `rabbitmq-ha` by default, to ensure cluster-redeployments do not fail due to unclean exits (#158) (by @moonrail)
 
 ## v0.32.0
 * Fix a bug when datastore encrypted keys didn't work in scheduled rules. datastore_crypto_key is now shared with the ``st2scheduler`` pods (#148) (by @rahulshinde26)

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: rabbitmq-ha
-    version: 1.44.1
+    version: 1.46.1
     repository: https://kubernetes-charts.storage.googleapis.com/
     condition: rabbitmq-ha.enabled
   - name: mongodb-replicaset

--- a/values.yaml
+++ b/values.yaml
@@ -450,6 +450,9 @@ rabbitmq-ha:
   # Change to `false` to disable in-cluster rabbitmq deployment.
   # Specify your external [messaging] connection parameters under st2.config
   enabled: true
+  # On unclean cluster restarts forceBoot is required to cleanup Mnesia tables (see: https://github.com/helm/charts/issues/13485)
+  # Use it only if you prefer availability over integrity.
+  forceBoot: true
   rabbitmqUsername: admin
   # TODO: Use default random 24 character password, but need to fetch this string for use by downstream services
   rabbitmqPassword: 9jS+w1u07NbHtZke1m+jW4Cj
@@ -458,7 +461,8 @@ rabbitmq-ha:
   #rabbitmqMemoryHighWatermark: 512MB
   #rabbitmqMemoryHighWatermarkType: absolute
   # Up to 255 character string, should be fixed so that re-deploying the chart does not fail (see: https://github.com/helm/charts/issues/12371)
-  #rabbitmqErlangCookie: 8MrqQdCQ6AQ8U3MacSubHE5RqkSfvNaRHzvxuFcG
+  # NB! It's highly recommended to change the default insecure rabbitmqErlangCookie value!
+  rabbitmqErlangCookie: 8MrqQdCQ6AQ8U3MacSubHE5RqkSfvNaRHzvxuFcG
   persistentVolume:
     enabled: true
   # RabbitMQ application vhost, should match with 'ha' Queue Mirroring definition policy
@@ -471,6 +475,10 @@ rabbitmq-ha:
   # Make sure to also change the rabbitmqMemoryHighWatermark following the formula:
   # rabbitmqMemoryHighWatermark = 0.4 * resources.limits.memory
   resources: {}
+  # As RabbitMQ enabled prometheus operator monitoring by default, disable it for non-prometheus users
+  prometheus:
+    operator:
+      enabled: false
 
 ##
 ## Etcd HA configuration (3rd party chart dependency)


### PR DESCRIPTION
Hello altogether

Potentially partly helps with the https://github.com/StackStorm/stackstorm-ha/issues/11

This Pull Request updates RabbitMQs-Chart-Dependency to 1.46.1, as on our kubernetes installations (1.17, 1.18, 1.19) 1.44.1 would not run due to mysterious disk-space complaints while being correctly assigned to a PersistentVolume and being able to RW to it.

As this new RabbitMQ-Version enables Prometheus-Monitoring by default, most of current installations would fail, therefore this is disabled it by default.

Enabled `rabbitmqErlangCookie`, as otherwise Cluster-Data is not reusable after RabbitMQ-Deployment-Restart/-Rebuild (or short period of 0 Replicas).

Added `forceBoot`, as otherwise Cluster-Data is not reusable after RabbitMQ-Deployment-Restart/-Rebuild (or short period of 0 Replicas), as Mnesia Tables are not cleaned up and cause RabbitMQ to not boot up. See https://github.com/helm/charts/issues/13485

So this should improve User Experience by not having to ditch PersistentVolumes after RabbitMQ-Redeployments.
<br>Not really sure about this - but if StackStorm holds queued Executions in RabbitMQ, this would also help in disaster cases, to not loose all running Executions.

Tested with 3.3dev on kubernetes 1.17, 1.18 & 1.19.

Please let me know, if there is something to improve. :)