### PR TITLE
Change pullPolicy to "IfNotPresent", as Docker-Hub Ratelimits now

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Change pullPolicy to "IfNotPresent", as Docker-Hub Ratelimits now (#159) (by @moonrail)
 
 
 ## v0.32.0

--- a/values.yaml
+++ b/values.yaml
@@ -5,8 +5,8 @@
 ## Docker image settings, applied to all StackStorm pods
 ##
 image:
-  # Image pull policy. Change to "IfNotPresent" when switching to stable images
-  pullPolicy: Always
+  # Image pull policy
+  pullPolicy: IfNotPresent
   # st2 image repository. Set this to override the default ("stackstorm") or enterprise
   # docker image repository ("docker.stackstorm.com"). Applies to all st2 containers except
   # st2chatops and st2packs (which have their own override). This also does not impact 
@@ -99,7 +99,7 @@ st2:
       #repository: your-remote-docker-registry.io
       name: st2packs
       tag: latest
-      pullPolicy: Always
+      pullPolicy: IfNotPresent
       # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry behind the auth
       #pullSecret: st2packs-auth
 
@@ -403,7 +403,7 @@ st2chatops:
     #name: st2chatops
     ## Note that Helm templating is supported in this block!
     #tag: "{{ .Chart.AppVersion }}"
-    #pullPolicy: Always
+    #pullPolicy: IfNotPresent
   # Tested requested resource consumption for st2chatops & hubot in normal mode
   # Please adjust based on your conscious choice
   resources:


### PR DESCRIPTION
Hello altogether

Docker-Hub introduced Ratelimiting: https://docs.docker.com/docker-hub/download-rate-limit/

While testing you will pull images a lot, also you may not want to always pull images, even on dev environments.

So I've figured, this would be a better default for most users.

Please let me know, if there is something to improve. :)