### PR TITLE
Added option for st2packs-PersistentVolumes to allow for seamless pack updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## In Development
-
+* Add option for st2packs-PersistentVolumes to allow for seamless custom pack-updates without job-impact (#160) (by @moonrail)
 
 ## v0.40.0
 * Switch st2 version to `v3.4dev` as a new latest development version (#157)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -158,39 +158,9 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      {{- if .Values.st2.packs.image.repository }}
+      {{- if and .Values.st2.packs.image.repository (not .Values.st2.packs.persistentVolumes) }}
       initContainers:
-      # Merge packs and virtualenvs from st2api with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ .Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+{{- include "packs-initContainers" . | indent 6 }}
       {{- end }}
       containers:
       - name: st2api{{ template "enterpriseSuffix" . }}
@@ -242,10 +212,7 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-config
         {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
+{{- include "packs-volumes" . | indent 8 }}
         {{- end }}
     {{- with .Values.st2api.nodeSelector }}
       nodeSelector:
@@ -923,37 +890,9 @@ spec:
       {{- if $.Values.image.pullSecret }}
       - name: {{ $.Values.image.pullSecret }}
       {{- end }}
-      {{- if $.Values.st2.packs.image.repository }}
+      {{- if and $.Values.st2.packs.image.repository (not $.Values.st2.packs.persistentVolumes) }}
       initContainers:
-      # Merge packs and virtualenvs from st2sensorcontainer with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ $.Values.st2.packs.image.repository }}/{{ $.Values.st2.packs.image.name }}:{{ $.Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ $.Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" $ }}/st2actionrunner{{ template "enterpriseSuffix" $ }}:{{ $.Chart.AppVersion }}"
-        imagePullPolicy: {{ $.Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+{{- include "packs-initContainers" $ | indent 6 }}
       {{- end }}
       containers:
       - name: st2sensorcontainer{{ template "hyphenPrefix" .name }}{{ template "enterpriseSuffix" $ }}
@@ -1018,10 +957,7 @@ spec:
           configMap:
             name: {{ $.Release.Name }}-st2-config
         {{- if $.Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
+{{- include "packs-volumes" $ | indent 8 }}
         {{- end }}
     {{- with .nodeSelector }}
       nodeSelector:
@@ -1092,37 +1028,9 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      {{- if .Values.st2.packs.image.repository }}
+      {{- if and .Values.st2.packs.image.repository (not .Values.st2.packs.persistentVolumes) }}
       initContainers:
-      # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ .Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+{{- include "packs-initContainers" . | indent 6 }}
       {{- end }}
       containers:
       - name: st2actionrunner{{ template "enterpriseSuffix" . }}
@@ -1183,10 +1091,7 @@ spec:
               # 0400 file permission
               mode: 256
         {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
+{{- include "packs-volumes" . | indent 8 }}
         {{- end }}
     {{- with .Values.st2actionrunner.nodeSelector }}
       nodeSelector:
@@ -1333,36 +1238,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- if .Values.st2.packs.image.repository }}
-      # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ .Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      {{- if and .Values.st2.packs.image.repository (not .Values.st2.packs.persistentVolumes) }}
+{{- include "packs-initContainers" . | indent 6 }}
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
@@ -1486,10 +1363,7 @@ spec:
               # 0400 file permission
               mode: 256
         {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
+{{- include "packs-volumes" . | indent 8 }}
         {{- end }}
 
 {{ if .Values.st2chatops.enabled -}}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -403,10 +403,5 @@ spec:
         - name: st2-pack-configs-vol
           configMap:
             name: {{ .Release.Name }}-st2-pack-configs
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
-        {{- end }}
+{{- include "packs-volumes" $ | indent 8}}
       restartPolicy: OnFailure

--- a/templates/persistentvolumeclaims.yaml
+++ b/templates/persistentvolumeclaims.yaml
@@ -1,0 +1,32 @@
+# This is only used, when user wants to share packs & venvs via persistentVolumes
+{{- if and .Values.st2.packs.image.repository .Values.st2.packs.persistentVolumes }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: st2-packs-pvol
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  resources:
+{{ toYaml .Values.st2.packs.persistentVolumes.packs.resources | indent 4 }}
+{{- if .Values.st2.packs.persistentVolumes.packs.storageClassName }}
+  storageClassName: "{{ .Values.st2.packs.persistentVolumes.packs.storageClassName }}"
+{{- end }}
+
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: st2-venv-pvol
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeMode: Filesystem
+  resources:
+{{ toYaml .Values.st2.packs.persistentVolumes.venvs.resources | indent 4 }}
+{{- if .Values.st2.packs.persistentVolumes.venvs.storageClassName }}
+  storageClassName: "{{ .Values.st2.packs.persistentVolumes.venvs.storageClassName }}"
+{{- end }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -96,13 +96,31 @@ st2:
         ---
         # example core pack config yaml
 
+    # Custom packs are shared via two persistent volumes across all containers
+    # Here you can customize these volumes, to accomodate to your specific requirements
+#    persistentVolumes:
+#      packs:
+#        resources:
+#          requests:
+        # If your packs bring a lot of files, this value may require a raise
+#            storage: 512Mi
+        # If your kubernetes cluster does not have a default storageClass set, you can provide a specific one here
+#        storageClassName: 'your_provider'
+#      venvs:
+#        resources:
+#          requests:
+        # If your packs require a lot of packages in their virtual environments, this value may require a raise
+#            storage: 1Gi
+        # If your kubernetes cluster does not have a default storageClass set, you can provide a specific one here
+#        storageClassName: 'your_provider'
+
     # Custom packs image settings. The repository, name, tag and pullPolicy for this image
     # are specified below.
     image:
       # Uncomment the following block to make the custom packs image available to the necessary pods
-      #repository: your-remote-docker-registry.io
+      # repository: index.docker.io/stackstorm
       name: st2packs
-      tag: latest
+      tag: example
       pullPolicy: IfNotPresent
       # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry behind the auth
       #pullSecret: st2packs-auth


### PR DESCRIPTION
> Related to the https://github.com/StackStorm/stackstorm-ha/pull/118 implementation discussion

Hello altogether

we have the requirement to frequently change st2packs via various pipelines and therefore found the default solution via initContainers/Sidecar not fitting, as actionrunner, sensor & api-containers were restarted on update.

Restarts are undesirable as Executions/Workflows will be "Abandoned", so we've searched for a k8s-native solution.

This Pull Request adds the option to use two shared PersistentVolumes (one for Packs, one for VirtualEnvironments) instead of initContainers per component.

Container `job-st2-register-content` is the only Container allowed to RW onto these PVs and will register content as usual after each upgrade/install via initContainers.

We've successfully updated packs and virtual environments while running Executions/Workflows and had no negative impact with this solution.

As not everybody can use PersistentVolumes and this should be held compatible to existing installations, the default pack-handling via initContainers is untouched.

Thanks to @AngryDeveloper in https://github.com/StackStorm/stackstorm-ha/pull/118 for the idea to deduplicate initContainer & Volume.

Tested with 3.3dev on kubernetes 1.17, 1.18 & 1.19.

Please let me know, if there is something to improve. :)