### PR TITLE
Add post-delete to jobs hook definition to remove them on uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## In Development
-
+* Add post-delete to jobs hook definition to remove them on uninstall (#161) (by @moonrail)
 
 ## v0.32.0
 * Fix a bug when datastore encrypted keys didn't work in scheduled rules. datastore_crypto_key is now shared with the ``st2scheduler`` pods (#148) (by @rahulshinde26)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -14,7 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     helm.sh/hook: post-install, post-upgrade, post-rollback
-    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation, post-delete
     helm.sh/hook-weight: "5"
 spec:
   template:
@@ -91,7 +91,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     helm.sh/hook: post-install, post-upgrade, post-rollback
-    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation, post-delete
     helm.sh/hook-weight: "6"
 spec:
   template:
@@ -190,7 +190,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     helm.sh/hook: post-install, post-upgrade, post-rollback
-    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation, post-delete
     helm.sh/hook-weight: "6"
 spec:
   template:
@@ -298,7 +298,7 @@ metadata:
     heritage: {{ .Release.Service }}
   annotations:
     helm.sh/hook: post-install, post-upgrade, post-rollback
-    helm.sh/hook-delete-policy: before-hook-creation
+    helm.sh/hook-delete-policy: before-hook-creation, post-delete
     helm.sh/hook-weight: "7"
 spec:
   template:


### PR DESCRIPTION

Hello altogether

on Chart uninstalls all jobs remain present.

This Pull Request adds `post-delete` to `hook-delete-policy`, so helm deletes them as well.

Please let me know, if there is something to improve. :)

Closes #101
