### PR TITLE
Added option to define a pull secret for regular st2 images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Update `rabbitmq-ha` 3rd party chart from `1.44.1` to `1.46.1` (#158) (by @moonrail)
 * Enable `rabbitmqErlangCookie` for `rabbitmq-ha` by default, to ensure cluster-redeployments do not fail (#158) (by @moonrail)
 * Add `forceBoot` for `rabbitmq-ha` by default, to ensure cluster-redeployments do not fail due to unclean exits (#158) (by @moonrail)
+* Add option to define pull secret for st2 images (#162) (by @moonrail)
 
 ## v0.32.0
 * Fix a bug when datastore encrypted keys didn't work in scheduled rules. datastore_crypto_key is now shared with the ``st2scheduler`` pods (#148) (by @rahulshinde26)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -34,9 +34,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       initContainers:
@@ -151,6 +154,9 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.pullSecret }}
       - name: {{ .Values.st2.packs.image.pullSecret }}
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
@@ -289,9 +295,12 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
       - name: st2stream{{ template "enterpriseSuffix" . }}
@@ -365,9 +374,12 @@ spec:
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
       - name: st2web{{ template "enterpriseSuffix" . }}
@@ -452,9 +464,12 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
       - name: st2rulesengine{{ template "enterpriseSuffix" . }}
@@ -539,9 +554,12 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
       - name: st2timersengine{{ template "enterpriseSuffix" . }}
@@ -618,9 +636,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
       - name: st2workflowengine{{ template "enterpriseSuffix" . }}
@@ -709,9 +730,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
       - name: st2scheduler{{ template "enterpriseSuffix" . }}
@@ -800,9 +824,12 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
       - name: st2notifier{{ template "enterpriseSuffix" . }}
@@ -892,6 +919,9 @@ spec:
       {{- end }}
       {{- if $.Values.st2.packs.image.pullSecret }}
       - name: {{ $.Values.st2.packs.image.pullSecret }}
+      {{- end }}
+      {{- if $.Values.image.pullSecret }}
+      - name: {{ $.Values.image.pullSecret }}
       {{- end }}
       {{- if $.Values.st2.packs.image.repository }}
       initContainers:
@@ -1059,6 +1089,9 @@ spec:
       {{- if .Values.st2.packs.image.pullSecret }}
       - name: {{ .Values.st2.packs.image.pullSecret }}
       {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
       # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
@@ -1203,9 +1236,12 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
       - name: st2garbagecollector{{ template "enterpriseSuffix" . }}
@@ -1292,6 +1328,9 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.pullSecret }}
       - name: {{ .Values.st2.packs.image.pullSecret }}
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
       {{- if .Values.st2.packs.image.repository }}
@@ -1488,6 +1527,10 @@ spec:
       annotations:
         checksum/chatops: {{ include (print $.Template.BasePath "/secrets_st2chatops.yaml") . | sha256sum }}
     spec:
+      {{- if .Values.image.pullSecret }}
+      imagePullSecrets:
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
       - name: st2chatops{{ template "enterpriseSuffix" . }}
         image: "{{ .Values.st2chatops.image.repository | default "stackstorm" }}/{{ .Values.st2chatops.image.name | default "st2chatops" }}:{{ tpl (.Values.st2chatops.image.tag | default .Chart.AppVersion) . }}"

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -35,6 +35,9 @@ spec:
     spec:
       imagePullSecrets:
       - name: {{ .Release.Name }}-st2-license
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
+      {{- end }}
       containers:
       - name: st2-apply-rbac-definitions
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -110,9 +113,12 @@ spec:
         checksum/urls: {{ include (print $.Template.BasePath "/configmaps_st2-urls.yaml") . | sha256sum }}
         checksum/apikeys: {{ include (print $.Template.BasePath "/secrets_st2apikeys.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
@@ -209,9 +215,12 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/urls: {{ include (print $.Template.BasePath "/configmaps_st2-urls.yaml") . | sha256sum }}
     spec:
-      {{- if .Values.enterprise.enabled }}
       imagePullSecrets:
+      {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
@@ -323,6 +332,9 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.pullSecret }}
       - name: {{ .Values.st2.packs.image.pullSecret }}
+      {{- end }}
+      {{- if .Values.image.pullSecret }}
+      - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,10 @@ image:
   # st2chatops and st2packs (which have their own override). This also does not impact 
   # dependencies such as mongo or redis, which have their own helm chart settings.
   repository: ""
+  # Image pull secret.
+  # May be required for public docker hub due to rate limiting or any private repository.
+  # See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+  #pullSecret: "your-pull-secret"
 
 
 ##


### PR DESCRIPTION
Hello again,

as https://github.com/StackStorm/stackstorm-ha/pull/159 already was aimed at "mitigating" Docker Hubs new policies, this PR also shoots in this direction.

With this PR it is possible to define a registry pull secret for regular StackStorm images, in addition to a repository.

This helps if a user is using a private repository without anonymous access or if an user paid a subscription at e.g. Docker Hub and does not want to think about Ratelimiting, etc.