### PR TITLE
New Location For Stable Charts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,10 +78,11 @@ jobs:
           command: sudo -E minikube start --vm-driver=none
           environment:
             CHANGE_MINIKUBE_NONE_USER: true
-      - helm/install-helm-client
       - run:
           name: Helm Init
-          command: helm init --stable-repo-url https://charts.helm.sh/stable
+          command: |
+            curl https://raw.githubusercontent.com/helm/helm/master/scripts/get | bash
+            helm init --stable-repo-url https://charts.helm.sh/stable
       - run:
           name: Update stackstorm-ha chart dependencies
           command: helm dependency update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,7 +78,10 @@ jobs:
           command: sudo -E minikube start --vm-driver=none
           environment:
             CHANGE_MINIKUBE_NONE_USER: true
-      - helm/install-helm-on-cluster
+      - helm/install-helm-client
+      - run:
+          name: Helm Init
+          command: helm init --stable-repo-url https://charts.helm.sh/stable
       - run:
           name: Update stackstorm-ha chart dependencies
           command: helm dependency update

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           name: Prepare Helm
           command: |
             set -x
-            helm init --client-only
+            helm init --stable-repo-url https://charts.helm.sh/stable --client-only
             helm dependency update
       - run:
           name: Helm Lint Check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## In Development
 
+## v0.41.0
+* Fix Helm 2 repository location to a new working URL https://charts.helm.sh/stable (#164) (by @manisha-tanwar)
 
 ## v0.40.0
 * Switch st2 version to `v3.4dev` as a new latest development version (#157)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 # Update StackStorm version here to rely on other Docker images tags
 appVersion: 3.4dev
 name: stackstorm-ha
-version: 0.40.0
+version: 0.41.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/
 icon: https://landscape.cncf.io/logos/stack-storm.svg

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,19 +1,19 @@
 dependencies:
   - name: rabbitmq-ha
     version: 1.46.1
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: rabbitmq-ha.enabled
   - name: mongodb-replicaset
     version: 3.12.0
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     alias: mongodb-ha
     condition: mongodb-ha.enabled
   - name: external-dns
     version: 1.6.1
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: external-dns.enabled
   - name: etcd-operator
     version: 0.10.3
-    repository: https://kubernetes-charts.storage.googleapis.com/
+    repository: https://charts.helm.sh/stable
     condition: etcd-operator.enabled
 

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -16,4 +16,3 @@ dependencies:
     version: 0.10.3
     repository: https://charts.helm.sh/stable
     condition: etcd-operator.enabled
-


### PR DESCRIPTION
Getting error 403 for existing chart location. Using updated URL works
https://helm.sh/blog/new-location-stable-incubator-charts/