### PR TITLE
Added option to define config.js for st2web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Add option to define config.js for st2web (#165) (by @moonrail)
 
 ## v0.51.0
 * Added Redis with Sentinel to replace etcd as a coordination backend (#169)

--- a/templates/configmaps_st2web.yaml
+++ b/templates/configmaps_st2web.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.st2web.config }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-st2web-config
+  annotations:
+    description: Custom StackStorm Web config which will override defaults
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    support: {{ template "supportMethod" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  # User-defined st2web config with custom settings to replace default config.js
+  # See https://github.com/StackStorm/st2web#connecting-to-st2-server for more info
+  st2web.config.js: |
+{{ .Values.st2web.config | indent 4 }}
+{{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -373,6 +373,8 @@ spec:
         chart: {{ .Chart.Name }}-{{ .Chart.Version }}
         release: {{ .Release.Name }}
         heritage: {{ .Release.Service }}
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2web.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
       {{- if .Values.enterprise.enabled }}
@@ -409,13 +411,27 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
             optional: true
+    {{- if .Values.st2web.config }}
+        volumeMounts:
+          - name: st2web-config-vol
+            mountPath: /opt/stackstorm/static/webui/config.js
+            subPath: st2web.config.js
+    {{- else }}
         volumeMounts: []
+    {{- end }}
         resources:
 {{ toYaml .Values.st2web.resources | indent 10 }}
     {{- if .Values.st2web.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
+    {{- if .Values.st2web.config }}
+      volumes:
+        - name: st2web-config-vol
+          configMap:
+            name: {{ .Release.Name }}-st2web-config
+    {{- else }}
       volumes: []
+    {{- end }}
     {{- with .Values.st2web.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -253,6 +253,10 @@ st2web:
   affinity: {}
   serviceAccount:
     attach: false
+  # User-defined st2web config with custom settings to replace default config.js
+  # See https://github.com/StackStorm/st2web#connecting-to-st2-server for more info
+  # config: |
+  #  // see https://github.com/StackStorm/st2web/blob/master/config.js
 # https://docs.stackstorm.com/reference/ha.html#st2auth
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
 st2auth:


### PR DESCRIPTION
Hello maintainers,

while testing and developing internally we've experienced the requirement, where we would have to access StackStorm in a subpath of a FQDN, e.g. `sub.domain.tld/stackstorm`.

For this configuration is required for Ingress and `st2web`.
<br>This PR adds the possibility to define configuration for `st2web`.

Ingress is pretty straight forward and already supported, e.g.:
```yaml
ingress:
    enabled: true
    annotations:
      kubernetes.io/ingress.class: nginx
      kubernetes.io/tls-acme: 'true'
      nginx.ingress.kubernetes.io/rewrite-target: /$1
    hosts: 
      - host: 'sub.domain.tld'
        paths:
          - path: '/stackstorm/(.*)'
            serviceName: st2web
            servicePort: 80
    tls:
      - secretName: 'tls-sub.domain.tld'
        hosts:
          - 'sub.domain.tld'
```

With this Ingress configuration, `st2web` is properly reachable.

By default `st2web` uses relative paths to its domain to access services like `auth`, `api`, and `stream`. So for our example, `st2web` would try to authenticate against `sub.domain.tld/auth`.
<br>A solution is described here: https://github.com/StackStorm/st2web#connecting-to-st2-server

In short: Edit /opt/stackstorm/static/webui/config.js to include complete Endpoints for `auth`, `api`, and `stream`.

For our example config.js could be:
```yaml
'use strict';

/* global angular */
angular.module('main')
  .constant('st2Config', {

    hosts: [
      {
        name: 'test',
        url: 'https://sub.domain.tld/stackstorm/api',
        auth: 'https://sub.domain.tld/stackstorm/auth',
        stream: 'https://sub.domain.tld/stackstorm/stream',
      }
    ]

  });
```