### PR TITLE
Allow multiple packs images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## In Development
-
+* Change st2packs definition to a list, to support multiple st2packs containers (#166) (by @moonrail)
 
 ## v0.52.0
 * Improve resource allocation and scheduling by adding resources requests cpu/memory values for st2 Pods (#179)

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ See [K8s documentation](https://kubernetes.io/docs/tasks/configure-pod-container
 # Create a Docker registry secret called 'st2packs-auth'
 kubectl create secret docker-registry st2packs-auth --docker-server=<your-registry-server> --docker-username=<your-name> --docker-password=<your-password>
 ```
-Once secret created, reference its name in helm value: `st2.packs.image.pullSecret`.
+Once secret created, reference its name in helm value: `st2.packs.images[].pullSecret`.
 
 
 ## Tips & Tricks

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1,3 +1,8 @@
+# Notify users about breaking change regarding packs, to not destroy current installations
+{{- if and .Values.st2.packs.image }}
+{{- fail "Value st2.packs.image was renamed to st2.packs.images and is now a list of images" }}
+{{- end }}
+
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -154,47 +159,17 @@ spec:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
-      {{- if .Values.st2.packs.image.pullSecret }}
-      - name: {{ .Values.st2.packs.image.pullSecret }}
-      {{- end }}
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
+      {{- end }}
+      {{- if .Values.st2.packs.images }}
+{{- include "packs-pullSecrets" . | indent 6 }}
       {{- end }}
       initContainers:
       {{ include "init-containers-wait-for-db" . | indent 6 }}
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
-      {{- if .Values.st2.packs.image.repository }}
-      # Merge packs and virtualenvs from st2api with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ .Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      {{- if .Values.st2.packs.images }}
+{{- include "packs-initContainers" . | indent 6 }}
       {{- end }}
       containers:
       - name: st2api{{ template "enterpriseSuffix" . }}
@@ -220,7 +195,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.image.repository }}
+        {{- if .Values.st2.packs.images }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
           readOnly: true
@@ -245,11 +220,8 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ .Release.Name }}-st2-config
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
+        {{- if .Values.st2.packs.images }}
+{{- include "packs-volumes" . | indent 8 }}
         {{- end }}
     {{- with .Values.st2api.nodeSelector }}
       nodeSelector:
@@ -955,45 +927,17 @@ spec:
       {{- if $.Values.enterprise.enabled }}
       - name: {{ $.Release.Name }}-st2-license
       {{- end }}
-      {{- if $.Values.st2.packs.image.pullSecret }}
-      - name: {{ $.Values.st2.packs.image.pullSecret }}
-      {{- end }}
       {{- if $.Values.image.pullSecret }}
       - name: {{ $.Values.image.pullSecret }}
+      {{- end }}
+      {{- if $.Values.st2.packs.images }}
+{{- include "packs-pullSecrets" $ | indent 6 }}
       {{- end }}
       initContainers:
       {{ include "init-containers-wait-for-db" $ | indent 6 }}
       {{ include "init-containers-wait-for-mq" $ | indent 6 }}
-      {{- if $.Values.st2.packs.image.repository }}
-      # Merge packs and virtualenvs from st2sensorcontainer with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ $.Values.st2.packs.image.repository }}/{{ $.Values.st2.packs.image.name }}:{{ $.Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ $.Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" $ }}/st2actionrunner{{ template "enterpriseSuffix" $ }}:{{ $.Chart.AppVersion }}"
-        imagePullPolicy: {{ $.Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      {{- if $.Values.st2.packs.images }}
+{{- include "packs-initContainers" $ | indent 6 }}
       {{- end }}
       containers:
       - name: st2sensorcontainer{{ template "hyphenPrefix" .name }}{{ template "enterpriseSuffix" $ }}
@@ -1027,7 +971,7 @@ spec:
         - name: st2-config-vol
           mountPath: /etc/st2/st2.user.conf
           subPath: st2.user.conf
-        {{- if $.Values.st2.packs.image.repository }}
+        {{- if $.Values.st2.packs.images }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
           readOnly: true
@@ -1057,11 +1001,8 @@ spec:
         - name: st2-config-vol
           configMap:
             name: {{ $.Release.Name }}-st2-config
-        {{- if $.Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
+        {{- if $.Values.st2.packs.images }}
+{{- include "packs-volumes" $ | indent 8 }}
         {{- end }}
     {{- with .nodeSelector }}
       nodeSelector:
@@ -1126,45 +1067,17 @@ spec:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
-      {{- if .Values.st2.packs.image.pullSecret }}
-      - name: {{ .Values.st2.packs.image.pullSecret }}
-      {{- end }}
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
+      {{- end }}
+      {{- if .Values.st2.packs.images }}
+{{- include "packs-pullSecrets" . | indent 6 }}
       {{- end }}
       initContainers:
       {{ include "init-containers-wait-for-db" . | indent 6 }}
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
-      {{- if .Values.st2.packs.image.repository }}
-      # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ .Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      {{- if .Values.st2.packs.images }}
+{{- include "packs-initContainers" . | indent 6 }}
       {{- end }}
       containers:
       - name: st2actionrunner{{ template "enterpriseSuffix" . }}
@@ -1191,7 +1104,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.image.repository }}
+        {{- if .Values.st2.packs.images }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
           readOnly: true
@@ -1224,11 +1137,8 @@ spec:
               path: stanley_rsa
               # 0400 file permission
               mode: 256
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
+        {{- if .Values.st2.packs.images }}
+{{- include "packs-volumes" . | indent 8 }}
         {{- end }}
     {{- with .Values.st2actionrunner.nodeSelector }}
       nodeSelector:
@@ -1371,43 +1281,15 @@ spec:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
-      {{- if .Values.st2.packs.image.pullSecret }}
-      - name: {{ .Values.st2.packs.image.pullSecret }}
+      {{- if .Values.st2.packs.images }}
+{{- include "packs-pullSecrets" . | indent 6 }}
       {{- end }}
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- if .Values.st2.packs.image.repository }}
-      # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ .Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      {{- if .Values.st2.packs.images }}
+{{- include "packs-initContainers" . | indent 6 }}
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
@@ -1477,7 +1359,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.image.repository }}
+        {{- if .Values.st2.packs.images }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
           readOnly: true
@@ -1530,11 +1412,8 @@ spec:
               path: stanley_rsa
               # 0400 file permission
               mode: 256
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
+        {{- if .Values.st2.packs.images }}
+{{- include "packs-volumes" . | indent 8 }}
         {{- end }}
 
 {{ if .Values.st2chatops.enabled -}}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -341,44 +341,16 @@ spec:
       {{- if .Values.enterprise.enabled }}
       - name: {{ .Release.Name }}-st2-license
       {{- end }}
-      {{- if .Values.st2.packs.image.pullSecret }}
-      - name: {{ .Values.st2.packs.image.pullSecret }}
-      {{- end }}
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      {{- if .Values.st2.packs.image.repository }}
+      {{- if $.Values.st2.packs.images -}}
+{{- include "packs-pullSecrets" . | indent 6 }}
+      {{- end }}
       initContainers:
       {{ include "init-containers-wait-for-db" . | indent 6 }}
-      # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
-      # Custom packs
-      - name: st2-custom-packs
-        image: "{{ .Values.st2.packs.image.repository }}/{{ .Values.st2.packs.image.name }}:{{ .Values.st2.packs.image.tag }}"
-        imagePullPolicy: {{ .Values.st2.packs.image.pullPolicy | quote }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-      # System packs
-      - name: st2-system-packs
-        image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.image.pullPolicy }}
-        volumeMounts:
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs-shared
-        command:
-          - 'sh'
-          - '-ec'
-          - |
-            /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
-            /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+      {{- if $.Values.st2.packs.images -}}
+ {{- include "packs-initContainers" . | indent 6 }}
       {{ end }}
       containers:
       - name: st2-register-content
@@ -400,7 +372,7 @@ spec:
           subPath: st2.user.conf
         - name: st2-pack-configs-vol
           mountPath: /opt/stackstorm/configs/
-        {{- if .Values.st2.packs.image.repository }}
+        {{- if .Values.st2.packs.images }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs/
         - name: st2-virtualenvs-vol
@@ -415,10 +387,5 @@ spec:
         - name: st2-pack-configs-vol
           configMap:
             name: {{ .Release.Name }}-st2-pack-configs
-        {{- if .Values.st2.packs.image.repository }}
-        - name: st2-packs-vol
-          emptyDir: {}
-        - name: st2-virtualenvs-vol
-          emptyDir: {}
-        {{- end }}
+ {{- include "packs-volumes" $ | indent 8}}
       restartPolicy: OnFailure

--- a/values.yaml
+++ b/values.yaml
@@ -96,16 +96,17 @@ st2:
         ---
         # example core pack config yaml
 
-    # Custom packs image settings. The repository, name, tag and pullPolicy for this image
-    # are specified below.
-    image:
-      # Uncomment the following block to make the custom packs image available to the necessary pods
-      #repository: your-remote-docker-registry.io
-      name: st2packs
-      tag: latest
-      pullPolicy: IfNotPresent
-      # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry behind the auth
-      #pullSecret: st2packs-auth
+    # Custom packs images settings.
+    # For each given st2packs container you can define repository, name, tag and pullPolicy for this image below.
+    # Multiple pack images can help when dealing with frequent updates by only rebuilding smaller images for desired packs
+    # E.g. having all desired StackStorm-Exchange packs in one image and several custom packs in additional images
+    images:
+      #- repository: index.docker.io/stackstorm
+      #  name: st2packs
+      #  tag: example
+      #  pullPolicy: IfNotPresent
+      # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry
+      #  pullSecret: st2packs-auth
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.


### PR DESCRIPTION
Hello Maintainers,

this PR adds the option to use multiple st2 packs-images.

This is a breaking change, as value `st2.packs.image` is replaced by `st2.packs.images`. Datatype changes from dict/hash to list of dicts/hashes.

This is useful, when a lot of different packs are being used, as a single container can result in multiple GB very quickly, mostly due to virtualenvs.

When using multiple st2 pack-images, the User can reduce possible downtimes due to reduced image size of new/changed containers. Also the build process can be a lot faster, if the User is providing custom packs.

Currently there is a fail message implemented in `templates/deployments.yaml` to prevent Users from accidential removal of their custom st2packs-image. It triggers, when `st2.packs.image` is defined and not empty. This should notify all Users about this change.

In #118 & #160 a centralization of packs-specific definitions for this chart was shown. As these PRs are still being discussed for other reasons, I've decided to include these centralizations in this PR.
This should make these PRs a little smaller and more compatible to each other, once they will or will not be finalized.