### PR TITLE
Setting redis as coordination backend

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,7 +50,7 @@ jobs:
   # Spin up minikube K8s cluster and run Helm chart & e2e tests on it
   helm-e2e:
     # 'large' 4 vCPUs & 15GB RAM CircleCI machine executor
-    # required to deploy heavy 'stackstorm-ha' Helm release with RabbitMQ, MongoDB, etcd clusters and 25+ st2 Pods.
+    # required to deploy heavy 'stackstorm-ha' Helm release with RabbitMQ, MongoDB, Redis clusters and 25+ st2 Pods.
     # https://circleci.com/docs/2.0/configuration-reference/#machine-executor-linux
     resource_class: large
     machine:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## In Development
 
+## v0.51.0
+* Added Redis with Sentinel to replace Etcd as backend coordinator (#167)
+
 ## v0.50.0
 * Drop Helm `v2` support and fully migrate to Helm `v3` (#163)
 * Switch dependencies from deprecated `helm/charts` to new Bitnami Subcharts (#163)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## In Development
 
 ## v0.51.0
-* Added Redis with Sentinel to replace Etcd as backend coordinator (#167)
+* Added Redis with Sentinel to replace etcd as a coordination backend (#169)
 
 ## v0.50.0
 * Drop Helm `v2` support and fully migrate to Helm `v3` (#163)

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -40,10 +40,6 @@ dependencies:
     version: 4.0.0
     repository: https://charts.bitnami.com/bitnami
     condition: external-dns.enabled
-  - name: etcd
-    version: 5.1.0
-    repository: https://charts.bitnami.com/bitnami
-    condition: etcd.enabled
   - name: redis
     version: 12.3.2
     repository: https://charts.bitnami.com/bitnami

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 # StackStorm version which refers to Docker images tag
 appVersion: 3.4dev
 name: stackstorm-ha
-version: 0.50.0
+version: 0.51.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/
 icon: https://landscape.cncf.io/logos/stack-storm.svg

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -44,3 +44,8 @@ dependencies:
     version: 5.1.0
     repository: https://charts.bitnami.com/bitnami
     condition: etcd.enabled
+  - name: redis
+    version: 12.3.2
+    repository: https://charts.bitnami.com/bitnami
+    condition: redis.enabled
+

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -76,3 +76,19 @@ Create the name of the stackstorm-ha service account to use
   {{- end -}}
 {{- end -}}
 {{- end -}}
+
+# Generate list of nodes for Redis with Sentinel connection string, based on number of replicas and service name
+{{- define "redis-nodes" -}}
+{{- if not .Values.redis.sentinel.enabled }}
+{{- fail "value for redis.sentinel.enabled MUST be true" }}
+{{- end }}
+{{- $replicas := (int (index .Values "redis" "cluster" "slaveCount")) }}
+{{- range $index0 := until $replicas -}}
+  {{- if eq $index0 0 -}}
+    {{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless:26379?sentinel=mymaster
+  {{- else -}}
+    &sentinel_fallback={{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless:26379
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+    

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -83,11 +83,13 @@ Create the name of the stackstorm-ha service account to use
 {{- fail "value for redis.sentinel.enabled MUST be true" }}
 {{- end }}
 {{- $replicas := (int (index .Values "redis" "cluster" "slaveCount")) }}
+{{- $master_name := (index .Values "redis" "sentinel" "masterSet") }}
+{{- $sentinel_port := (index .Values "redis" "sentinel" "port") }}
 {{- range $index0 := until $replicas -}}
   {{- if eq $index0 0 -}}
-    {{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless:26379?sentinel=mymaster
+    {{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless:{{ $sentinel_port }}?sentinel={{ $master_name }}
   {{- else -}}
-    &sentinel_fallback={{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless:26379
+    &sentinel_fallback={{ $.Release.Name }}-redis-node-{{ $index0 }}.{{ $.Release.Name }}-redis-headless:{{ $sentinel_port }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -24,6 +24,10 @@ data:
     [coordination]
     url = etcd://{{ index .Values "etcd" "fullnameOverride" }}:2379
     {{- end }}
+    {{- if index .Values "redis" "enabled" }}
+    [coordination]
+    url = redis://st2ha-redis-node-0.st2ha-redis-headless:26379?sentinel=mymaster&sentinel_fallback=st2ha-redis-node-1.st2ha-redis-headless:26379&sentinel_fallback=st2ha-redis-node-2.st2ha-redis-headless:26379
+    {{- end }}
     {{- if index .Values "rabbitmq" "enabled" }}
     [messaging]
     url = amqp://{{ required "rabbitmq.auth.username is required!" (index .Values "rabbitmq" "auth" "username") }}:{{ required "rabbitmq.auth.password is required!" (index .Values "rabbitmq" "auth" "password") }}@{{ .Release.Name }}-rabbitmq:5672{{ required "rabbitmq.ingress.path is required!" (index .Values "rabbitmq" "ingress" "path") }}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -26,7 +26,7 @@ data:
     {{- end }}
     {{- if index .Values "redis" "enabled" }}
     [coordination]
-    url = redis://st2ha-redis-node-0.st2ha-redis-headless:26379?sentinel=mymaster&sentinel_fallback=st2ha-redis-node-1.st2ha-redis-headless:26379&sentinel_fallback=st2ha-redis-node-2.st2ha-redis-headless:26379
+    url = redis://{{ .Release.Name }}-redis-node-0.{{ .Release.Name }}-redis-headless:26379?sentinel=mymaster&sentinel_fallback={{ .Release.Name }}-redis-node-1.{{ .Release.Name }}-redis-headless:26379&sentinel_fallback={{ .Release.Name }}-redis-node-2.{{ .Release.Name }}-redis-headless:26379
     {{- end }}
     {{- if index .Values "rabbitmq" "enabled" }}
     [messaging]

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -20,13 +20,9 @@ data:
   st2.docker.conf: |
     [auth]
     api_url = http://{{ .Release.Name }}-st2api{{ template "enterpriseSuffix" . }}:9101/
-    {{- if index .Values "etcd" "enabled" }}
-    [coordination]
-    url = etcd://{{ index .Values "etcd" "fullnameOverride" }}:2379
-    {{- end }}
     {{- if index .Values "redis" "enabled" }}
     [coordination]
-    url = redis://{{ .Release.Name }}-redis-node-0.{{ .Release.Name }}-redis-headless:26379?sentinel=mymaster&sentinel_fallback={{ .Release.Name }}-redis-node-1.{{ .Release.Name }}-redis-headless:26379&sentinel_fallback={{ .Release.Name }}-redis-node-2.{{ .Release.Name }}-redis-headless:26379
+    url = redis://{{ template "redis-nodes" $ }}
     {{- end }}
     {{- if index .Values "rabbitmq" "enabled" }}
     [messaging]

--- a/tests/st2tests.sh
+++ b/tests/st2tests.sh
@@ -57,3 +57,20 @@ load "${BATS_HELPERS_DIR}/bats-file/load.bash"
   assert_success
   assert_line --partial 'chatops.notify'
 }
+
+@test 'st2 key/value operations are functional' {
+  run st2 key set foo bar
+  assert_success
+
+  run st2 key get foo
+  assert_success
+  assert_line --partial 'bar'
+
+  run st2 key delete foo
+  assert_line --partial '"foo" has been successfully deleted'
+  assert_success
+
+  run st2 key get foo
+  assert_line --partial '"foo" is not found'
+  assert_failure
+}

--- a/values.yaml
+++ b/values.yaml
@@ -523,6 +523,31 @@ etcd:
   fullnameOverride: etcd
 
 ##
+## Redis HA configuration (3rd party chart dependency)
+##
+## For values.yaml reference:
+## https://github.com/bitnami/charts/tree/master/bitnami/redis
+##
+redis:
+  # Change to `false` to disable in-cluster redis deployment.
+  # Specify your external [coordination] connection parameters under st2.config
+  enabled: true
+  cluster:
+    enabled: true
+    slaveCount: 3
+  # ## Sentinel settings. Sentinel is enabled for better resiliency.
+  # ## https://docs.openstack.org/tooz/latest/user/drivers.html#redis
+  # ## https://github.com/bitnami/charts/tree/master/bitnami/redis#master-slave-with-sentinel
+  sentinel:
+    enabled: true
+  networkPolicy:
+    enabled: false
+  usePassword: false
+  #password: "PLoT2g3gvD"
+  metrics:
+    enabled: false
+
+##
 ## External DNS configuration (3rd party chart dependency)
 ##
 ## Creates a deployment of external-dns within the cluster to update DNS with CNAME -> ELB

--- a/values.yaml
+++ b/values.yaml
@@ -517,7 +517,7 @@ rabbitmq:
 etcd:
   # Change to `false` to disable in-cluster ectd deployment.
   # Specify your external [coordination] connection parameters under st2.config
-  enabled: true
+  enabled: false
   statefulset:
     replicaCount: 3
   fullnameOverride: etcd

--- a/values.yaml
+++ b/values.yaml
@@ -509,20 +509,6 @@ rabbitmq:
     enabled: false
 
 ##
-## Etcd HA configuration (3rd party chart dependency)
-##
-## For values.yaml reference:
-## https://github.com/bitnami/charts/tree/master/bitnami/etcd
-##
-etcd:
-  # Change to `false` to disable in-cluster ectd deployment.
-  # Specify your external [coordination] connection parameters under st2.config
-  enabled: false
-  statefulset:
-    replicaCount: 3
-  fullnameOverride: etcd
-
-##
 ## Redis HA configuration (3rd party chart dependency)
 ##
 ## For values.yaml reference:
@@ -532,10 +518,13 @@ redis:
   # Change to `false` to disable in-cluster redis deployment.
   # Specify your external [coordination] connection parameters under st2.config
   enabled: true
+  # By default the cluster is enabled for the subchart.
+  # We just need replica count here to ensure it is HA
   cluster:
-    enabled: true
     slaveCount: 3
   # ## Sentinel settings. Sentinel is enabled for better resiliency.
+  # ## This is highly recommended as per tooz library documentation. 
+  # ## Hence, the chart requires the setting.
   # ## https://docs.openstack.org/tooz/latest/user/drivers.html#redis
   # ## https://github.com/bitnami/charts/tree/master/bitnami/redis#master-slave-with-sentinel
   sentinel:
@@ -543,7 +532,6 @@ redis:
   networkPolicy:
     enabled: false
   usePassword: false
-  #password: "PLoT2g3gvD"
   metrics:
     enabled: false
 


### PR DESCRIPTION
Closes https://github.com/StackStorm/stackstorm-ha/issues/94
Fixes https://github.com/StackStorm/stackstorm-ha/issues/167


For the time-being...
1. The release name is hard-wired in the connection string. This means, please use `st2ha` as the release name. 
2. Password is not enabled.
3. `sentinel=mymaster` in the connection string has been set assuming the name of the master is the name of the masterset. 

Below is the error I have been receiving...

```
2021-01-12 03:13:00,478 ERROR [-] (PID=1) ST2 API quit due to exception.
Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/tooz/drivers/redis.py", line 47, in _translate_failures
    yield
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/tooz/drivers/redis.py", line 457, in _start
    self._server_info = self._client.info()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/redis/client.py", line 1304, in info
    return self.execute_command('INFO')
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/redis/client.py", line 898, in execute_command
    conn = self.connection or pool.get_connection(command_name, **options)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/redis/connection.py", line 1192, in get_connection
    connection.connect()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/redis/sentinel.py", line 44, in connect
    self.connect_to(self.connection_pool.get_master_address())
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/redis/sentinel.py", line 107, in get_master_address
    self.service_name)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/redis/sentinel.py", line 219, in discover_master
    raise MasterNotFoundError("No master found for %r" % (service_name,))
redis.sentinel.MasterNotFoundError: No master found for 'mymaster'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/cmd/api.py", line 86, in main
    return _run_server()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/cmd/api.py", line 75, in _run_server
    wsgi.server(sock, app.setup_app(), custom_pool=worker_pool, log=LOG, log_output=False)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/app.py", line 77, in setup_app
    router.add_spec(spec, transforms=transforms)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/router.py", line 213, in add_spec
    __import__(module_name)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/controllers/v1/keyvalue.py", line 437, in <module>
    key_value_pair_controller = KeyValuePairController()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2api/controllers/v1/keyvalue.py", line 62, in __init__
    self._coordinator = coordination.get_coordinator()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/services/coordination.py", line 227, in get_coordinator
    COORDINATOR = coordinator_setup(start_heart=start_heart)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/st2common/services/coordination.py", line 200, in coordinator_setup
    coordinator.start(start_heart=start_heart)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/tooz/coordination.py", line 690, in start
    super(CoordinationDriverWithExecutor, self).start(start_heart)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/tooz/coordination.py", line 426, in start
    self._start()
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/tooz/drivers/redis.py", line 457, in _start
    self._server_info = self._client.info()
  File "/usr/lib/python3.6/contextlib.py", line 99, in __exit__
    self.gen.throw(type, value, traceback)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/tooz/drivers/redis.py", line 51, in _translate_failures
    cause=e)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/tooz/utils.py", line 225, in raise_with_cause
    excutils.raise_with_cause(exc_cls, message, *args, **kwargs)
  File "/opt/stackstorm/st2/lib/python3.6/site-packages/oslo_utils/excutils.py", line 143, in raise_with_cause
    six.raise_from(exc_cls(message, *args, **kwargs), kwargs.get('cause'))
  File "<string>", line 3, in raise_from
tooz.coordination.ToozConnectionError: No master found for 'mymaster'


```