### PR TITLE
Publish stackstorm-ha Helm chart on Artifact Hub

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -44,4 +44,3 @@ dependencies:
     version: 12.3.2
     repository: https://charts.bitnami.com/bitnami
     condition: redis.enabled
-

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # `stackstorm-ha` Helm Chart
 [![Build Status](https://circleci.com/gh/StackStorm/stackstorm-ha/tree/master.svg?style=shield)](https://circleci.com/gh/StackStorm/stackstorm-ha)
+[![Artifact HUB](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/stackstorm-ha)](https://artifacthub.io/packages/helm/stackstorm/stackstorm-ha)
 
 K8s Helm Chart for running StackStorm cluster in HA mode.
 


### PR DESCRIPTION
Closes https://github.com/StackStorm/stackstorm-ha/issues/2.

Publish `stackstorm-ha` on Artifact Hub: https://artifacthub.io/packages/helm/stackstorm/stackstorm-ha, which is a new home for the Helm charts after official https://github.com/helm/charts/ deprecation.