### PR TITLE
Introduced initContainers to wait for DB/MQ availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
-## v0.52.0
-* Implemented initContainers to wait for DB/MQ to be available for St2 Pods (#178)
-
 ## In Development
+* Implemented initContainers to wait for DB/MQ to be available for St2 Pods (#178)
 * Add option to define config.js for st2web (#165) (by @moonrail)
 
 ## v0.51.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.52.0
+* Implemented initContainers to wait for DB/MQ to be available for St2 Pods (#178)
+
 ## In Development
 * Add option to define config.js for st2web (#165) (by @moonrail)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 # StackStorm version which refers to Docker images tag
 appVersion: 3.4dev
 name: stackstorm-ha
-version: 0.51.0
+version: 0.52.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/
 icon: https://landscape.cncf.io/logos/stack-storm.svg

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 # StackStorm version which refers to Docker images tag
 appVersion: 3.4dev
 name: stackstorm-ha
-version: 0.52.0
+version: 0.51.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/
 icon: https://landscape.cncf.io/logos/stack-storm.svg

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -94,3 +94,36 @@ Create the name of the stackstorm-ha service account to use
 {{- end -}}
 {{- end -}}
     
+{{- define "init-containers-wait-for-db" -}}
+{{- if index .Values "mongodb" "enabled" }}
+{{- $mongodb_port := (int (index .Values "mongodb" "service" "port")) }}
+- name: wait-for-db
+  image: busybox:1.28
+  command:
+    - 'sh'
+    - '-c'
+    - >
+      until nc -z -w 2 {{ $.Release.Name }}-mongodb-headless {{ $mongodb_port }} && echo mongodb ok;
+        do 
+          echo 'Waiting for MongoDB Connection...'
+          sleep 2;
+      done
+{{- end }}
+{{- end -}}
+
+{{- define "init-containers-wait-for-mq" -}}
+{{- if index .Values "rabbitmq" "enabled" }}
+{{- $rabbitmq_port := (int (index .Values "rabbitmq" "service" "port")) }}
+- name: wait-for-queue
+  image: busybox:1.28
+  command:
+    - 'sh'
+    - '-c'
+    - >
+      until nc -z -w 2 {{ $.Release.Name }}-rabbitmq {{ $rabbitmq_port }} && echo rabbitmq ok;
+        do
+          echo 'Waiting for RabbitMQ Connection...'
+          sleep 2;
+      done
+{{- end }}
+{{- end -}}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -43,6 +43,24 @@ spec:
       {{- end }}
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       - name: generate-htpasswd
         image: "{{ template "imageRepository" . }}/st2auth{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -158,8 +176,26 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      {{- if .Values.st2.packs.image.repository }}
       initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
+      {{- if .Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2api with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
@@ -302,6 +338,25 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       containers:
       - name: st2stream{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2stream{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -487,6 +542,25 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       containers:
       - name: st2rulesengine{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2rulesengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -577,6 +651,25 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       containers:
       - name: st2timersengine{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2timersengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -659,6 +752,25 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       containers:
       - name: st2workflowengine{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2workflowengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -753,6 +865,25 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       containers:
       - name: st2scheduler{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2scheduler{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -847,6 +978,25 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       containers:
       - name: st2notifier{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2notifier{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -939,8 +1089,26 @@ spec:
       {{- if $.Values.image.pullSecret }}
       - name: {{ $.Values.image.pullSecret }}
       {{- end }}
-      {{- if $.Values.st2.packs.image.repository }}
       initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ $.Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ $.Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
+      {{- if $.Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2sensorcontainer with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
@@ -1108,8 +1276,26 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      {{- if .Values.st2.packs.image.repository }}
       initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
+      {{- if .Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs
@@ -1259,6 +1445,25 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
+      initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       containers:
       - name: st2garbagecollector{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2garbagecollector{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -1349,6 +1554,24 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-queue
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
+              do sleep 2;
+            done
       {{- if .Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -41,26 +41,10 @@ spec:
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
-      # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
+      # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       - name: generate-htpasswd
         image: "{{ template "imageRepository" . }}/st2auth{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
@@ -177,24 +161,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       {{- if .Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2api with those from the st2.packs image
       # Custom packs
@@ -339,24 +307,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2stream{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2stream{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -543,24 +495,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2rulesengine{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2rulesengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -652,24 +588,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2timersengine{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2timersengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -753,24 +673,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2workflowengine{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2workflowengine{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -866,24 +770,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2scheduler{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2scheduler{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -979,24 +867,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2notifier{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2notifier{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -1090,24 +962,8 @@ spec:
       - name: {{ $.Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ $.Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ $.Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" $ | indent 6 }}
+      {{ include "init-containers-wait-for-mq" $ | indent 6 }}
       {{- if $.Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2sensorcontainer with those from the st2.packs image
       # Custom packs
@@ -1277,24 +1133,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       {{- if .Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs
@@ -1446,24 +1286,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
+      {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2garbagecollector{{ template "enterpriseSuffix" . }}
         image: "{{ template "imageRepository" . }}/st2garbagecollector{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -1554,24 +1378,6 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
-      - name: wait-for-queue
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-rabbitmq 5672 && echo rabbitmq ok;
-              do sleep 2;
-            done
       {{- if .Values.st2.packs.image.repository }}
       # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -121,15 +121,7 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
       - name: wait-for-api
         image: busybox:1.28
         command:
@@ -241,15 +233,7 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -365,15 +349,7 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
-      - name: wait-for-db
-        image: busybox:1.28
-        command:
-          - 'sh'
-          - '-c'
-          - >
-            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
-              do sleep 2;
-            done
+      {{ include "init-containers-wait-for-db" . | indent 6 }}
       # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -121,6 +121,24 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
+      - name: wait-for-api
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-st2api 9101 && echo st2api ready;
+              do sleep 2;
+            done
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -223,6 +241,15 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
         image: "{{ template "imageRepository" . }}/st2actionrunner{{ template "enterpriseSuffix" . }}:{{ .Chart.AppVersion }}"
@@ -338,6 +365,15 @@ spec:
       {{- end }}
       {{- if .Values.st2.packs.image.repository }}
       initContainers:
+      - name: wait-for-db
+        image: busybox:1.28
+        command:
+          - 'sh'
+          - '-c'
+          - >
+            until nc -z -w 2 {{ .Release.Name }}-mongodb-headless 27017 && echo mongodb ok;
+              do sleep 2;
+            done
       # Merge packs and virtualenvs from st2actionrunner with those from the st2.packs image
       # Custom packs
       - name: st2-custom-packs


### PR DESCRIPTION
Closes #11

Added initContainers for waiting on DB and MQ dependencies to be formed and connected before proceeding to initialize dependent containers of ST2 services.