### PR TITLE
Added resource Requests values for St2 Pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Added resources requests cpu/memory values for St2 Pods (#179)
 * Implemented initContainers to wait for DB/MQ to be available for St2 Pods (#178)
 * Add option to define config.js for st2web (#165) (by @moonrail)
 

--- a/values.yaml
+++ b/values.yaml
@@ -119,8 +119,10 @@ st2:
         livenessProbe: {}
         readinessProbe: {}
         annotations: {}
-        # TODO: Find out recommended/default resources for this specific service (#5)
-        resources: {}
+        resources:
+          requests:
+            memory: "100Mi"
+            cpu: "50m"
         # Additional advanced settings to control pod/deployment placement
         affinity: {}
         nodeSelector: {}
@@ -261,8 +263,10 @@ st2web:
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
 st2auth:
   replicas: 2
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "85Mi"
+      cpu: "50m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -273,8 +277,10 @@ st2auth:
 # Multiple st2api process can be behind a load balancer in an active-active configuration.
 st2api:
   replicas: 2
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "150Mi"
+      cpu: "25m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -285,8 +291,10 @@ st2api:
 # Multiple st2stream process can be behind a load balancer in an active-active configuration.
 st2stream:
   replicas: 2
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "50m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -297,8 +305,10 @@ st2stream:
 # Multiple st2rulesengine processes can run in active-active with only connections to MongoDB and RabbitMQ. All these will share the TriggerInstance load and naturally pick up more work if one or more of the processes becomes unavailable.
 st2rulesengine:
   replicas: 2
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "75Mi"
+      cpu: "25m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -308,8 +318,10 @@ st2rulesengine:
 # https://docs.stackstorm.com/reference/ha.html#st2timersengine
 # Only single replica is created via K8s Deployment as timersengine can't work in active-active mode at the moment and it relies on K8s failover/reschedule capabilities to address cases of process failure.
 st2timersengine:
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "75Mi"
+      cpu: "10m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -320,8 +332,10 @@ st2timersengine:
 # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
 st2workflowengine:
   replicas: 2
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu: "100m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -332,8 +346,10 @@ st2workflowengine:
 # TODO: Description TBD
 st2scheduler:
   replicas: 2
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "75Mi"
+      cpu: "50m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -344,8 +360,10 @@ st2scheduler:
 # st2notifier runs in active-active mode and requires for that coordination backend like Redis or Zookeeper
 st2notifier:
   replicas: 2
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "75Mi"
+      cpu: "50m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -357,8 +375,10 @@ st2notifier:
 # distributed across runners via RabbitMQ. Adding more st2actionrunner processes increases the ability of StackStorm to execute actions.
 st2actionrunner:
   replicas: 5
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "200Mi"
+      cpu: "75m"
   annotations: {}
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
@@ -382,8 +402,10 @@ st2actionrunner:
 st2garbagecollector:
   # Having 1 st2garbagecollector unique replica is enough for periodic task like st2 history garbage collection
   replicas: 1
-  # TODO: Find out recommended/default resources for this specific service (#5)
-  resources: {}
+  resources:
+    requests:
+      memory: "80Mi"
+      cpu: "10m"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Closes #5 
The values are added based on production monitoring average base on during peak/off-peak hours.
Please note: While I have not been able to test this in `minikube` due to unrelated reasons, below is the resource utilization of the `3` nodes cluster with `t3.large (2 CPUs/8GB Memory)` spec.

```❯ kubectl top node
NAME                             CPU(cores)   CPU%   MEMORY(bytes)   MEMORY%
ip-192-168-137-84.ec2.internal   428m         22%    2587Mi          36%
ip-192-168-171-99.ec2.internal   279m         14%    3048Mi          42%
ip-192-168-99-86.ec2.internal    237m         12%    2640Mi          37%
```