### PR TITLE
Release stackstorm-ha v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## In Development
+
+
+## v0.52.0
 * Added resources requests cpu/memory values for St2 Pods (#179)
 * Implemented initContainers to wait for DB/MQ to be available for St2 Pods (#178)
 * Add option to define config.js for st2web (#165) (by @moonrail)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 
 ## v0.52.0
-* Added resources requests cpu/memory values for St2 Pods (#179)
-* Implemented initContainers to wait for DB/MQ to be available for St2 Pods (#178)
+* Improve resource allocation and scheduling by adding resources requests cpu/memory values for st2 Pods (#179)
+* Avoid cluster restart loop situations by making st2 Pod initContainers to wait for DB/MQ connection (#178)
 * Add option to define config.js for st2web (#165) (by @moonrail)
 
 ## v0.51.0

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 # StackStorm version which refers to Docker images tag
 appVersion: 3.4dev
 name: stackstorm-ha
-version: 0.51.0
+version: 0.52.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/
 icon: https://landscape.cncf.io/logos/stack-storm.svg


### PR DESCRIPTION
Cutting a new stackstorm-ha version `v0.52.0` based on Community contributions:

* Improve resource allocation and scheduling by adding resources requests cpu/memory values for st2 Pods (#179)
* Avoid cluster restart loop situations by making st2 Pod initContainers to wait for DB/MQ connection (#178)
* Add option to define config.js for st2web (#165) (by @moonrail)

thanks @arms11 and @moonrail for those improvements :+1: 