### PR TITLE
Release new Chart v0.60.0 with st2 3.5dev

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## In Development
+
+
+## v0.60.0
+* Switch st2 version to `v3.5dev` as a new latest development version (#187)
 * Change st2packs definition to a list, to support multiple st2packs containers (#166) (by @moonrail)
 * Enabled RBAC/LDAP configuration for OSS version, removed enterprise flags (#182) (by @hnanchahal)
 

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 # StackStorm version which refers to Docker images tag
-appVersion: "3.4dev"
+appVersion: "3.5dev"
 name: stackstorm-ha
-version: 0.52.0
+version: 0.60.0
 description: StackStorm K8s Helm Chart, optimized for running StackStorm in HA environment.
 home: https://stackstorm.com/
 icon: https://landscape.cncf.io/logos/stack-storm.svg


### PR DESCRIPTION
Breaking changes in this release:

* Switch to the latest st2 `v3.5dev` as app version
* Change st2packs definition to a list, to support multiple st2packs containers (#166) (by @moonrail)
* Rework RBAC/LDAP configuration for OSS, remove previously enterprise flags (#182) (by @hnanchahal)
* Fixed datastore_crypto_key secret name for rules engine (#188) (by @lordpengwin)
