### PR TITLE
Issue 188: st2rulesengine references datastore_crypto_key incorrectly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Change st2packs definition to a list, to support multiple st2packs containers (#166) (by @moonrail)
 * Enabled RBAC/LDAP configuration for OSS version, removed enterprise flags (#182) (by @hnanchahal)
+* Fixed datastore_crypto_key secret name for rules engine (#188) (by @lordpengwin)
 
 ## v0.52.0
 * Improve resource allocation and scheduling by adding resources requests cpu/memory values for st2 Pods (#179)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -468,7 +468,7 @@ spec:
         {{- if .Values.secrets.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
-            secretName: datastore_crypto_key
+            secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json


### PR DESCRIPTION
I fixed the secret name for the rules engine

Closes #190