### PR TITLE
Add redis.staticID feature to allow constant sentinel ids 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 # Changelog
 
 ## In Development
-
+* Updated redis constant sentinel ID which will allow other sentinel peers to update to the new given IP in case of pod failure or worker node reboots. (#191) (by @manisha-tanwar)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)
 * Change st2packs definition to a list, to support multiple st2packs containers (#166) (by @moonrail)
 * Enabled RBAC/LDAP configuration for OSS version, removed enterprise flags (#182) (by @hnanchahal)
 * Fixed datastore_crypto_key secret name for rules engine (#188) (by @lordpengwin)
-* Updated redis constant sentinel ID which will allow other sentinel peers to update to the new given IP in case of pod failure or worker node reboots. (#191) (by @manisha-tanwar)
 
 ## v0.52.0
 * Improve resource allocation and scheduling by adding resources requests cpu/memory values for st2 Pods (#179)

--- a/values.yaml
+++ b/values.yaml
@@ -547,6 +547,10 @@ redis:
   # ## https://github.com/bitnami/charts/tree/master/bitnami/redis#master-slave-with-sentinel
   sentinel:
     enabled: true
+    ## Enable or disable static sentinel IDs for each replicas
+    ## If disabled each sentinel will generate a random id at startup
+    ## If enabled, each replicas will have a constant ID on each start-up
+    ##
     staticID: true
   networkPolicy:
     enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -540,17 +540,16 @@ redis:
   # We just need replica count here to ensure it is HA
   cluster:
     slaveCount: 3
-  # ## Sentinel settings. Sentinel is enabled for better resiliency.
-  # ## This is highly recommended as per tooz library documentation. 
-  # ## Hence, the chart requires the setting.
-  # ## https://docs.openstack.org/tooz/latest/user/drivers.html#redis
-  # ## https://github.com/bitnami/charts/tree/master/bitnami/redis#master-slave-with-sentinel
+  # Sentinel settings. Sentinel is enabled for better resiliency.
+  # This is highly recommended as per tooz library documentation. 
+  # Hence, the chart requires the setting.
+  # https://docs.openstack.org/tooz/latest/user/drivers.html#redis
+  # https://github.com/bitnami/charts/tree/master/bitnami/redis#master-slave-with-sentinel
   sentinel:
     enabled: true
-    ## Enable or disable static sentinel IDs for each replicas
-    ## If disabled each sentinel will generate a random id at startup
-    ## If enabled, each replicas will have a constant ID on each start-up
-    ##
+    # Enable or disable static sentinel IDs for each replicas
+    # If disabled each sentinel will generate a random id at startup
+    # If enabled, each replicas will have a constant ID on each start-up
     staticID: true
   networkPolicy:
     enabled: false

--- a/values.yaml
+++ b/values.yaml
@@ -547,6 +547,7 @@ redis:
   # ## https://github.com/bitnami/charts/tree/master/bitnami/redis#master-slave-with-sentinel
   sentinel:
     enabled: true
+    staticID: true
   networkPolicy:
     enabled: false
   usePassword: false


### PR DESCRIPTION
Redis sentinel not able to elect master & all pods goes into CrashLoopBackOff when worker nodes are rebooted or 2 pods crashes for any reason.
[https://github.com/helm/charts/pull/19059](https://github.com/helm/charts/pull/19059)