### PR TITLE
remove lingering reference to enterprise st2-license pullSecret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Updated redis constant sentinel ID which will allow other sentinel peers to update to the new given IP in case of pod failure or worker node reboots. (#191) (by @manisha-tanwar)
+* Removed reference to st2-license pullSecrets, which was missed when removing enterprise flags (#192) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -32,7 +32,6 @@ spec:
         checksum/rbac: {{ include (print $.Template.BasePath "/configmaps_rbac.yaml") . | sha256sum }}
     spec:
       imagePullSecrets:
-      - name: {{ .Release.Name }}-st2-license
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}
       {{- end }}


### PR DESCRIPTION
There was one more reference to `{{ .Release.name }}-st2-license` which was removed everywhere else in #182.
This removes the straggler.

As a follow-up to the already merged #182, this should not need a changelog entry. _edit: added changelog entry_