### PR TITLE
Allow adding nodeSelector, affinity, tolerations to batch Jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add image.tag overrides for all deployments. (#200) (by @cognifloyd)
 * If your k8s cluster admin requires custom annotations (eg: to indicate mongo or rabbitmq usage), you can now add those to each set of pods. (#195) (by @cognifloyd)
 * Add optional hubot-scripts volume to st2chatops pod. To add this, define `st2chatops.hubotScriptsVolume`. (#207) (by @cognifloyd)
+* Add advanced pod placment (nodeSelector, affinity, tolerations) to specs for batch Jobs pods. (#193) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -77,6 +77,15 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
       restartPolicy: OnFailure
+    {{- with .Values.jobs.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jobs.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jobs.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+    {{- end }}
 
 {{- end }}
 ---
@@ -188,6 +197,15 @@ spec:
           secret:
             secretName: {{ .Release.Name }}-st2-apikeys
       restartPolicy: OnFailure
+    {{- with .Values.jobs.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jobs.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jobs.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+    {{- end }}
 
 ---
 apiVersion: batch/v1
@@ -298,6 +316,15 @@ spec:
           secret:
             secretName: {{ .Release.Name }}-st2-kv
       restartPolicy: OnFailure
+    {{- with .Values.jobs.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jobs.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jobs.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+    {{- end }}
 
 ---
 apiVersion: batch/v1
@@ -383,3 +410,12 @@ spec:
             name: {{ .Release.Name }}-st2-pack-configs
         {{- include "packs-volumes" $ | nindent 8 }}
       restartPolicy: OnFailure
+    {{- with .Values.jobs.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jobs.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.jobs.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -531,6 +531,10 @@ jobs:
   image: {}
     ## Note that Helm templating is supported in this block!
     #tag: "{{ .Values.image.tag }}"
+  # Additional advanced settings to control pod/deployment placement
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
 
 ##
 ## MongoDB HA configuration (3rd party chart dependency)


### PR DESCRIPTION
Our cluster has dedicated nodes for StackStorm. So I need a way to specify the advanced placement settings (nodeSelector, affinity, tolerations) on the batch jobs as well.

- ~add advanced-pod-placement helper. This reduces duplication in the deployments file.~ _edit: moved to #216_
- add advanced pod/deployment placement settings for Jobs
- add changelog entry