### PR TITLE
Allow custom annotations on all pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Reformat some yaml strings so that single quotes wrap strings that include double quotes (#194) (by @cognifloyd)
 * st2chatops change: If `st2chatops.env.ST2_API_KEY` is defined, do not set `ST2_AUTH_USERNAME` or `ST2_AUTH_PASSWORD` env vars any more. (#197) (by @cognifloyd)
 * Add image.tag overrides for all deployments. (#200) (by @cognifloyd)
+* If your k8s cluster admin requires custom annotations (eg: to indicate mongo or rabbitmq usage), you can now add those to each set of pods. (#195) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -105,6 +105,13 @@ Create the name of the stackstorm-ha service account to use
   {{- end }}
 {{- end -}}
 
+# Reusable annotations list
+{{- define "custom-annotations" -}}
+  {{- if .annotations }}
+{{ toYaml .annotations }}
+  {{- end }}
+{{- end -}}
+
 # For custom st2packs-Container reduce duplicity by defining it here once
 {{- define "packs-volumes" -}}
   {{- if .Values.st2.packs.images }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -105,13 +105,6 @@ Create the name of the stackstorm-ha service account to use
   {{- end }}
 {{- end -}}
 
-# Reusable annotations list
-{{- define "custom-annotations" -}}
-  {{- if .annotations }}
-{{ toYaml .annotations }}
-  {{- end }}
-{{- end -}}
-
 # For custom st2packs-Container reduce duplicity by defining it here once
 {{- define "packs-volumes" -}}
   {{- if .Values.st2.packs.images }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -35,6 +35,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2auth | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -145,6 +146,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2api | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -255,6 +257,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2stream | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -333,6 +336,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2web.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2web | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -431,6 +435,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2rulesengine | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -518,6 +523,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2timersengine | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -597,6 +603,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2workflowengine | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -688,6 +695,7 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2scheduler | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -779,6 +787,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2notifier | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -862,9 +871,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") $ | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") $ | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") $ | sha256sum }}
-        {{- if .annotations }}
-{{ toYaml .annotations | indent 8 }}
-        {{- end }}
+{{ include "custom-annotations" . | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if $.Values.image.pullSecret }}
@@ -992,9 +999,7 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-        {{- if .Values.st2actionrunner.annotations }}
-{{ toYaml .Values.st2actionrunner.annotations | indent 8 }}
-        {{- end }}
+{{ include "custom-annotations" .Values.st2actionrunner | indent 8 }}
     spec:
       {{- if .Values.st2actionrunner.hostAliases }}
       hostAliases:
@@ -1118,6 +1123,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2garbagecollector | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -1199,6 +1205,7 @@ spec:
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2client | indent 8 }}
     spec:
       imagePullSecrets:
       {{- if .Values.st2.packs.images }}
@@ -1367,6 +1374,7 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/chatops: {{ include (print $.Template.BasePath "/secrets_st2chatops.yaml") . | sha256sum }}
+{{ include "custom-annotations" .Values.st2chatops | indent 8 }}
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -35,7 +35,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2auth | indent 8 }}
+        {{- if .Values.st2auth.annotations }}
+{{ toYaml .Values.st2auth.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -146,7 +148,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2api | indent 8 }}
+        {{- if .Values.st2api.annotations }}
+{{ toYaml .Values.st2api.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -257,7 +261,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2stream | indent 8 }}
+        {{- if .Values.st2stream.annotations }}
+{{ toYaml .Values.st2stream.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -336,7 +342,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2web.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2web | indent 8 }}
+        {{- if .Values.st2web.annotations }}
+{{ toYaml .Values.st2web.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -435,7 +443,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2rulesengine | indent 8 }}
+        {{- if .Values.st2rulesengine.annotations }}
+{{ toYaml .Values.st2rulesengine.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -523,7 +533,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2timersengine | indent 8 }}
+        {{- if .Values.st2timersengine.annotations }}
+{{ toYaml .Values.st2timersengine.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -603,7 +615,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2workflowengine | indent 8 }}
+        {{- if .Values.st2workflowengine.annotations }}
+{{ toYaml .Values.st2workflowengine.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -695,7 +709,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2scheduler | indent 8 }}
+        {{- if .Values.st2scheduler.annotations }}
+{{ toYaml .Values.st2scheduler.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -787,7 +803,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2notifier | indent 8 }}
+        {{- if .Values.st2notifier.annotations }}
+{{ toYaml .Values.st2notifier.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -871,7 +889,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") $ | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") $ | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") $ | sha256sum }}
-{{ include "custom-annotations" . | indent 8 }}
+        {{- if .annotations }}
+{{ toYaml .annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if $.Values.image.pullSecret }}
@@ -999,7 +1019,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2actionrunner | indent 8 }}
+        {{- if .Values.st2actionrunner.annotations }}
+{{ toYaml .Values.st2actionrunner.annotations | indent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.st2actionrunner.hostAliases }}
       hostAliases:
@@ -1123,7 +1145,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2garbagecollector | indent 8 }}
+        {{- if .Values.st2garbagecollector.annotations }}
+{{ toYaml .Values.st2garbagecollector.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -1205,7 +1229,9 @@ spec:
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2client | indent 8 }}
+        {{- if .Values.st2client.annotations }}
+{{ toYaml .Values.st2client.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.st2.packs.images }}
@@ -1374,7 +1400,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/chatops: {{ include (print $.Template.BasePath "/secrets_st2chatops.yaml") . | sha256sum }}
-{{ include "custom-annotations" .Values.st2chatops | indent 8 }}
+        {{- if .Values.st2chatops.annotations }}
+{{ toYaml .Values.st2chatops.annotations | indent 8 }}
+        {{- end }}
     spec:
       {{- if .Values.image.pullSecret }}
       imagePullSecrets:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -15,9 +15,7 @@ metadata:
     {{- if .Values.ingress.tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
-    {{- range $key, $value := .Values.ingress.annotations }}
-    {{ $key }}: {{ $value | quote }}
-    {{- end }}
+{{ include "custom-annotations" .Values.ingress | indent 4 }}
 spec:
   rules:
   {{- range .Values.ingress.hosts }}

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -15,7 +15,9 @@ metadata:
     {{- if .Values.ingress.tls }}
     ingress.kubernetes.io/secure-backends: "true"
     {{- end }}
-{{ include "custom-annotations" .Values.ingress | indent 4 }}
+    {{- if .Values.ingress.annotations }}
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+    {{- end }}
 spec:
   rules:
   {{- range .Values.ingress.hosts }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -30,6 +30,9 @@ spec:
         # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/rbac: {{ include (print $.Template.BasePath "/configmaps_rbac.yaml") . | sha256sum }}
+        {{- if .Values.jobs.annotations }}
+{{ toYaml .Values.jobs.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -58,7 +61,6 @@ spec:
           mountPath: /opt/stackstorm/rbac/assignments/
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
-{{ include "custom-annotations" .Values.jobs | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -108,6 +110,9 @@ spec:
         # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
         checksum/urls: {{ include (print $.Template.BasePath "/configmaps_st2-urls.yaml") . | sha256sum }}
         checksum/apikeys: {{ include (print $.Template.BasePath "/secrets_st2apikeys.yaml") . | sha256sum }}
+        {{- if .Values.jobs.annotations }}
+{{ toYaml .Values.jobs.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -173,7 +178,6 @@ spec:
         - name: st2-apikeys-vol
           mountPath: /etc/st2/apikeys.yaml
           subPath: apikeys.yaml
-{{ include "custom-annotations" .Values.jobs | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -216,6 +220,9 @@ spec:
         # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/urls: {{ include (print $.Template.BasePath "/configmaps_st2-urls.yaml") . | sha256sum }}
+        {{- if .Values.jobs.annotations }}
+{{ toYaml .Values.jobs.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -278,7 +285,6 @@ spec:
         - name: st2-kv-vol
           mountPath: /etc/st2/st2kv.yaml
           subPath: st2kv.yaml
-{{ include "custom-annotations" .Values.jobs | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -324,6 +330,9 @@ spec:
         # TODO: Investigate/propose running Helm hook only on condition when ConfigMap or Secret has changed
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") . | sha256sum }}
+        {{- if .Values.jobs.annotations }}
+{{ toYaml .Values.jobs.annotations | indent 8 }}
+        {{- end }}
     spec:
       imagePullSecrets:
       {{- if .Values.image.pullSecret }}
@@ -363,7 +372,6 @@ spec:
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs/
         {{- end }}
-{{ include "custom-annotations" .Values.jobs | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -58,6 +58,7 @@ spec:
           mountPath: /opt/stackstorm/rbac/assignments/
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
+{{ include "custom-annotations" .Values.jobs | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -172,6 +173,7 @@ spec:
         - name: st2-apikeys-vol
           mountPath: /etc/st2/apikeys.yaml
           subPath: apikeys.yaml
+{{ include "custom-annotations" .Values.jobs | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -276,6 +278,7 @@ spec:
         - name: st2-kv-vol
           mountPath: /etc/st2/st2kv.yaml
           subPath: st2kv.yaml
+{{ include "custom-annotations" .Values.jobs | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
@@ -360,6 +363,7 @@ spec:
         - name: st2-virtualenvs-vol
           mountPath: /opt/stackstorm/virtualenvs/
         {{- end }}
+{{ include "custom-annotations" .Values.jobs | indent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:

--- a/values.yaml
+++ b/values.yaml
@@ -242,6 +242,7 @@ st2web:
       cpu: "50m"
     limits:
       memory: "100Mi"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -274,6 +275,7 @@ st2auth:
     requests:
       memory: "85Mi"
       cpu: "50m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -292,6 +294,7 @@ st2api:
     requests:
       memory: "150Mi"
       cpu: "25m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -310,6 +313,7 @@ st2stream:
     requests:
       memory: "100Mi"
       cpu: "50m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -328,6 +332,7 @@ st2rulesengine:
     requests:
       memory: "75Mi"
       cpu: "25m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -345,6 +350,7 @@ st2timersengine:
     requests:
       memory: "75Mi"
       cpu: "10m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -363,6 +369,7 @@ st2workflowengine:
     requests:
       memory: "200Mi"
       cpu: "100m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -381,6 +388,7 @@ st2scheduler:
     requests:
       memory: "75Mi"
       cpu: "50m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -399,6 +407,7 @@ st2notifier:
     requests:
       memory: "75Mi"
       cpu: "50m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -442,6 +451,7 @@ st2actionrunner:
 # The st2client deployment/pod simplifies ad-hoc administration.
 # st2client is a special purpose actionrunner pod, but you can customize it separately
 st2client:
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -457,6 +467,7 @@ st2garbagecollector:
     requests:
       memory: "80Mi"
       cpu: "10m"
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!
@@ -498,6 +509,7 @@ st2chatops:
     requests:
       memory: "50Mi"
       cpu: "5m"
+  annotations: {}
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -509,6 +521,7 @@ st2chatops:
 ## Various batch jobs (apply-rbac-definitions, apikey-load, key-load, register-content)
 ##
 jobs:
+  annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   image: {}
     ## Note that Helm templating is supported in this block!


### PR DESCRIPTION
In our k8s cluster, we requires custom annotations (eg: to indicate mongo or rabbitmq usage) to simplify cluster-wide maintenance on shared services. This PR makes it possible to add those to each set of pods.

- allow custom annotations for all pods
- use custom-annotations helper for ingress as well
- add changelog entry