### PR TITLE
Add the ability to define imagePullSecrets for service account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Updated redis constant sentinel ID which will allow other sentinel peers to update to the new given IP in case of pod failure or worker node reboots. (#191) (by @manisha-tanwar)
+* Add optional imagePullSecrets to ServiceAccount using `serviceAccount.pullSecret` from values.yaml. If pods do not have imagePullSecrets (eg without `image.pullSecret` in values.yaml), k8s populates them from the ServiceAccount. (#196) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/service-account.yaml
+++ b/templates/service-account.yaml
@@ -13,4 +13,8 @@ metadata:
     app: "{{ template "stackstorm-ha.name" . }}"
     heritage: "{{ .Release.Service }}"
     release: "{{ .Release.Name }}"
+  {{- if .Values.serviceAccount.pullSecret }}
+  imagePullSecrets:
+  - name: "{{ .Values.serviceAccount.pullSecret }}"
+  {{- end }}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -29,6 +29,10 @@ serviceAccount:
   serviceAccountAnnotations: {}
   # Used to override service account name
   serviceAccountName:
+  # Fallback image pull secret.
+  # If a pod does not have pull secrets, k8s will use the service account's pull secrets.
+  # See: https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#serviceaccount-admission-controller
+  #pullSecret: "your-pull-secret"
 
 ##
 ## StackStorm shared variables


### PR DESCRIPTION
If pods do not have imagePullSecrets, they get populated from the ServiceAccount[1]. In our k8s cluster, we prefer defining them on the ServiceAccount so that there are fewer places to update if a change is required.

Effectively, this means we can use `serviceAccount.pullSecret` instead of `image.pullSecret` in values.yaml.

[1] From [the k8s docs](https://kubernetes.io/docs/reference/access-authn-authz/service-accounts-admin/#serviceaccount-admission-controller):
> 5. If the pod does not contain any imagePullSecrets, then imagePullSecrets of the ServiceAccount are added to the pod.

TODO:
- [x] PR description
- [x] changelog entry