### PR TITLE
Allow setting an ST2_API_KEY for st2chatops instead of user/pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * Removed reference to st2-license pullSecrets, which was missed when removing enterprise flags (#192) (by @cognifloyd)
 * Add optional imagePullSecrets to ServiceAccount using `serviceAccount.pullSecret` from values.yaml. If pods do not have imagePullSecrets (eg without `image.pullSecret` in values.yaml), k8s populates them from the ServiceAccount. (#196) (by @cognifloyd)
 * Reformat some yaml strings so that single quotes wrap strings that include double quotes (#194) (by @cognifloyd)
+* Add `st2chatops.api_key` value so that the st2chatops deployment can get the ST2_API_KEY env var instead of ST2_AUTH_USERNAME/PASSWORD. (#197) (by @cognifloyd)
+
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Removed reference to st2-license pullSecrets, which was missed when removing enterprise flags (#192) (by @cognifloyd)
 * Add optional imagePullSecrets to ServiceAccount using `serviceAccount.pullSecret` from values.yaml. If pods do not have imagePullSecrets (eg without `image.pullSecret` in values.yaml), k8s populates them from the ServiceAccount. (#196) (by @cognifloyd)
 * Reformat some yaml strings so that single quotes wrap strings that include double quotes (#194) (by @cognifloyd)
-* Add `st2chatops.api_key` value so that the st2chatops deployment can get the ST2_API_KEY env var instead of ST2_AUTH_USERNAME/PASSWORD. (#197) (by @cognifloyd)
+* st2chatops change: If `st2chatops.env.ST2_API_KEY` is defined, do not set `ST2_AUTH_USERNAME` or `ST2_AUTH_PASSWORD` env vars any more. (#197) (by @cognifloyd)
 
 
 ## v0.60.0

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1376,14 +1376,8 @@ spec:
       - name: st2chatops
         image: '{{ .Values.st2chatops.image.repository | default "stackstorm" }}/{{ .Values.st2chatops.image.name | default "st2chatops" }}:{{ tpl (.Values.st2chatops.image.tag | default .Chart.AppVersion) . }}'
         imagePullPolicy: {{ .Values.st2chatops.image.pullPolicy | default .Values.image.pullPolicy }}
+        {{- if not (hasKey .Values.st2chatops.env "ST2_API_KEY") }}
         env:
-        {{- if index .Values.st2chatops "api_key" }}
-        - name: ST2_API_KEY
-          valueFrom:
-            secretKeyRef:
-              name: {{ .Release.Name }}-st2-auth
-              key: chatops_api_key
-        {{- else }}
         - name: ST2_AUTH_USERNAME
           valueFrom:
             secretKeyRef:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1377,6 +1377,13 @@ spec:
         image: '{{ .Values.st2chatops.image.repository | default "stackstorm" }}/{{ .Values.st2chatops.image.name | default "st2chatops" }}:{{ tpl (.Values.st2chatops.image.tag | default .Chart.AppVersion) . }}'
         imagePullPolicy: {{ .Values.st2chatops.image.pullPolicy | default .Values.image.pullPolicy }}
         env:
+        {{- if index .Values.st2chatops "use_api_key" }}
+        - name: ST2_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-st2-auth
+              key: chatops_api_key
+        {{- else }}
         - name: ST2_AUTH_USERNAME
           valueFrom:
             secretKeyRef:
@@ -1387,6 +1394,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-st2-auth
               key: password
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1377,7 +1377,7 @@ spec:
         image: '{{ .Values.st2chatops.image.repository | default "stackstorm" }}/{{ .Values.st2chatops.image.name | default "st2chatops" }}:{{ tpl (.Values.st2chatops.image.tag | default .Chart.AppVersion) . }}'
         imagePullPolicy: {{ .Values.st2chatops.image.pullPolicy | default .Values.image.pullPolicy }}
         env:
-        {{- if index .Values.st2chatops "use_api_key" }}
+        {{- if index .Values.st2chatops "api_key" }}
         - name: ST2_API_KEY
           valueFrom:
             secretKeyRef:

--- a/templates/secrets_st2auth.yaml
+++ b/templates/secrets_st2auth.yaml
@@ -18,7 +18,7 @@ data:
   username: {{ required "A valid secret 'st2.username' is required for StackStorm auth!" .Values.secrets.st2.username | b64enc | quote }}
   # Password, used to login to StackStorm system (default: Ch@ngeMe)
   password: {{ required "A valid secret 'st2.password' is required for StackStorm auth!" .Values.secrets.st2.password | b64enc | quote }}
-  {{- if index .Values.st2chatops "use_api_key" }}
+  {{- if index .Values.st2chatops "api_key" }}
   # Optional api_key for chatops to use instead of username/password
-  chatops_api_key: {{ required "A valid secret 'st2.chatops_api_key' is required for StackStorm Chatops auth!" .Values.secrets.st2.api_key | b64enc | quote }}
+  chatops_api_key: {{ .Values.st2chatops.api_key | b64enc | quote }}
   {{- end }}

--- a/templates/secrets_st2auth.yaml
+++ b/templates/secrets_st2auth.yaml
@@ -18,7 +18,3 @@ data:
   username: {{ required "A valid secret 'st2.username' is required for StackStorm auth!" .Values.secrets.st2.username | b64enc | quote }}
   # Password, used to login to StackStorm system (default: Ch@ngeMe)
   password: {{ required "A valid secret 'st2.password' is required for StackStorm auth!" .Values.secrets.st2.password | b64enc | quote }}
-  {{- if index .Values.st2chatops "api_key" }}
-  # Optional api_key for chatops to use instead of username/password
-  chatops_api_key: {{ .Values.st2chatops.api_key | b64enc | quote }}
-  {{- end }}

--- a/templates/secrets_st2auth.yaml
+++ b/templates/secrets_st2auth.yaml
@@ -18,3 +18,7 @@ data:
   username: {{ required "A valid secret 'st2.username' is required for StackStorm auth!" .Values.secrets.st2.username | b64enc | quote }}
   # Password, used to login to StackStorm system (default: Ch@ngeMe)
   password: {{ required "A valid secret 'st2.password' is required for StackStorm auth!" .Values.secrets.st2.password | b64enc | quote }}
+  {{- if index .Values.st2chatops "use_api_key" }}
+  # Optional api_key for chatops to use instead of username/password
+  chatops_api_key: {{ required "A valid secret 'st2.chatops_api_key' is required for StackStorm Chatops auth!" .Values.secrets.st2.api_key | b64enc | quote }}
+  {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -422,9 +422,9 @@ st2chatops:
   env:
     HUBOT_ADAPTER: slack
     HUBOT_SLACK_TOKEN: xoxb-CHANGE-ME-PLEASE
-  # If api_key is defined, then use this key instead of username/password for chatops to authenticate with StackStorm.
-  # Please make sure that this key gets added to st2.apikeys above so that chatops can use this key.
-  #api_key:
+    # If ST2_API_KEY is defined, then ST2_AUTH_USERNAME/PASSWORD will not be exposed to st2chatops.
+    # Please make sure that the key in ST2_API_KEY gets added to st2.apikeys above so that chatops can use this key.
+    #ST2_API_KEY: 12345
   # Set custom generated st2chatops Docker image source
   # Otherwise default https://hub.docker.com/r/stackstorm/st2chatops is used
   image: {}

--- a/values.yaml
+++ b/values.yaml
@@ -422,9 +422,9 @@ st2chatops:
   env:
     HUBOT_ADAPTER: slack
     HUBOT_SLACK_TOKEN: xoxb-CHANGE-ME-PLEASE
-  # If use_api_key is true, then use secrets.st2.api_key instead of username/password for chatops
-  # to authenticate with StackStorm.
-  use_api_key: false
+  # If api_key is defined, then use this key instead of username/password for chatops to authenticate with StackStorm.
+  # Please make sure that this key gets added to st2.apikeys above so that chatops can use this key.
+  #api_key:
   # Set custom generated st2chatops Docker image source
   # Otherwise default https://hub.docker.com/r/stackstorm/st2chatops is used
   image: {}

--- a/values.yaml
+++ b/values.yaml
@@ -422,6 +422,9 @@ st2chatops:
   env:
     HUBOT_ADAPTER: slack
     HUBOT_SLACK_TOKEN: xoxb-CHANGE-ME-PLEASE
+  # If use_api_key is true, then use secrets.st2.api_key instead of username/password for chatops
+  # to authenticate with StackStorm.
+  use_api_key: false
   # Set custom generated st2chatops Docker image source
   # Otherwise default https://hub.docker.com/r/stackstorm/st2chatops is used
   image: {}


### PR DESCRIPTION
Whenever I setup chatops, I prefer giving chatops an api_key instead of a username/password combo.

This PR allows us to add a previously generated st2 api_key as `st2chatops.api_key` in `values.yaml` (make sure to add the api_key object in `st2.apikeys` as well). Defining this api_key triggers replacing the `ST2_AUTH_USERNAME` and `ST2_AUTH_PASSWORD` environment vars with `ST2_API_KEY` but only for the st2chatops deployment.