### PR TITLE
Refactor: Use helper for st2-config-vol volume/volumeMounts definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Add optional hubot-scripts volume to st2chatops pod. To add this, define `st2chatops.hubotScriptsVolume`. (#207) (by @cognifloyd)
 * Add advanced pod placment (nodeSelector, affinity, tolerations) to specs for batch Jobs pods. (#193) (by @cognifloyd)
 * Allow adding dnsPolicy and/or dnsConfig to all pods. (#201) (by @cognifloyd)
+* Move st2-config-vol volume definition and list of st2-config-vol volumeMounts to helpers to reduce duplication (#198) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -71,6 +71,21 @@ Create the name of the stackstorm-ha service account to use
 {{- end -}}
 {{- end -}}
     
+# Reduce duplication of the st2.*.conf volume details
+{{- define "st2-config-volume-mounts" -}}
+- name: st2-config-vol
+  mountPath: /etc/st2/st2.docker.conf
+  subPath: st2.docker.conf
+- name: st2-config-vol
+  mountPath: /etc/st2/st2.user.conf
+  subPath: st2.user.conf
+{{- end -}}
+{{- define "st2-config-volume" -}}
+- name: st2-config-vol
+  configMap:
+    name: {{ $.Release.Name }}-st2-config
+{{- end -}}
+
 {{- define "init-containers-wait-for-db" -}}
 {{- if index .Values "mongodb" "enabled" }}
 {{- $mongodb_port := (int (index .Values "mongodb" "service" "port")) }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -81,12 +81,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8  }}
         - name: htpasswd-vol
           mountPath: /etc/st2/htpasswd
           subPath: htpasswd
@@ -97,9 +92,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         - name: htpasswd-vol
           emptyDir:
             medium: Memory
@@ -181,12 +174,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -214,9 +202,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2.packs.images }}
 {{- include "packs-volumes" . | indent 8 }}
         {{- end }}
@@ -291,21 +277,14 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         resources:
           {{- toYaml .Values.st2stream.resources | nindent 10 }}
     {{- if .Values.st2stream.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -477,21 +456,14 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         resources:
           {{- toYaml .Values.st2rulesengine.resources | nindent 10 }}
     {{- if .Values.st2rulesengine.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
@@ -570,21 +542,14 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         resources:
           {{- toYaml .Values.st2timersengine.resources | nindent 10 }}
     {{- if .Values.st2timersengine.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -655,12 +620,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -672,9 +632,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
@@ -752,12 +710,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -777,9 +730,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -849,21 +800,14 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         resources:
           {{- toYaml .Values.st2notifier.resources | nindent 10 }}
     {{- if .Values.st2notifier.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -959,12 +903,7 @@ spec:
         - configMapRef:
             name: {{ $.Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" $ | nindent 8 }}
         {{- if $.Values.st2.packs.images }}
         - name: st2-packs-vol
           mountPath: /opt/stackstorm/packs
@@ -992,9 +931,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        - name: st2-config-vol
-          configMap:
-            name: {{ $.Release.Name }}-st2-config
+        {{- include "st2-config-volume" $ | nindent 8 }}
         {{- if $.Values.st2.packs.images }}
 {{- include "packs-volumes" $ | indent 8 }}
         {{- end }}
@@ -1081,12 +1018,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
           readOnly: true
@@ -1117,9 +1049,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         - name: st2-ssh-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-ssh
@@ -1200,21 +1130,14 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         resources:
           {{- toYaml .Values.st2garbagecollector.resources | nindent 10 }}
     {{- if .Values.st2garbagecollector.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -1322,12 +1245,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol
           mountPath: /opt/stackstorm/rbac/roles/
@@ -1373,9 +1291,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol
           configMap:

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -49,12 +49,7 @@ spec:
           - --config-file=/etc/st2/st2.docker.conf
           - --config-file=/etc/st2/st2.user.conf
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-rbac-roles-vol
           mountPath: /opt/stackstorm/rbac/roles/
         - name: st2-rbac-assignments-vol
@@ -64,9 +59,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         - name: st2-rbac-roles-vol
           configMap:
             name: {{ .Release.Name }}-st2-rbac-roles
@@ -304,12 +297,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-kv-vol
@@ -318,9 +306,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
@@ -403,12 +389,7 @@ spec:
           - --register-all
           - --register-fail-on-failure
         volumeMounts:
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.docker.conf
-          subPath: st2.docker.conf
-        - name: st2-config-vol
-          mountPath: /etc/st2/st2.user.conf
-          subPath: st2.user.conf
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-pack-configs-vol
           mountPath: /opt/stackstorm/configs/
         {{- if .Values.st2.packs.images }}
@@ -420,9 +401,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
-        - name: st2-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-config
+        {{- include "st2-config-volume" . | nindent 8 }}
         - name: st2-pack-configs-vol
           configMap:
             name: {{ .Release.Name }}-st2-pack-configs


### PR DESCRIPTION
This reduces duplication of the st2-config-vol definitions in `volumes:` and `volumeMounts:` blocks.