### PR TITLE
Add custom packs volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@
 * Make system_user configurable when using custom st2actionrunner images that do not provide stanley (#220) (by @cognifloyd)
 * Allow providing scripts in values for use in lifecycle postStart hooks of all deployments. (#206) (by @cognifloyd)
 * Add preRegisterContentCommand in an initContainer for register-content job to run last-minute content customizations (#213) (by @cognifloyd)
-* New feature: Shared packs volumes `st2.packs.volumes` -- Instead of using `st2packs` images to install packs, allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. (#199) (by @cognifloyd)
+* New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Make system_user configurable when using custom st2actionrunner images that do not provide stanley (#220) (by @cognifloyd)
 * Allow providing scripts in values for use in lifecycle postStart hooks of all deployments. (#206) (by @cognifloyd)
 * Add preRegisterContentCommand in an initContainer for register-content job to run last-minute content customizations (#213) (by @cognifloyd)
+* New feature: Shared packs volumes `st2.packs.volumes` -- Instead of using `st2packs` images to install packs, allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. (#199) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/README.md
+++ b/README.md
@@ -286,6 +286,23 @@ Or, for example, to use NFS:
         path: /var/nfsshare/configs
 ```
 
+#### Caveat: Mounting and copying packs
+If you use something like NFS where you can mount the shares outside of the StackStorm pods, there are a couple of things to keep in mind.
+
+Though you could manually copy packs into the `packs` shared volume, be aware that StackStorm does not automatically register any changed content.
+So, if you manually copy a pack into the `packs` shared volume, then you also need to trigger updating the virtualenv and registering the content,
+possibly using APIs like:
+[packs/install](https://api.stackstorm.com/api/v1/packs/#/packs_controller.install.post), and
+[packs/register](https://api.stackstorm.com/api/v1/packs/#/packs_controller.register.post)
+You will have to repeat the process each time the packs code is modified.
+
+#### Caveat: System packs
+After Helm installs, upgrades, or rolls back a StackStorm install, it runs an `st2-register-content` batch job.
+This job will copy and register system packs. If you have made any changes (like disabling default aliases), those changes will be overwritten.
+
+NOTE: Upgrades will not remove files (such as a renamed or removed action) if they were removed in newer StackStorm versions.
+This mirrors the how pack registration works. Make sure to review any upgrade notes and manually handle any removals.
+
 ## Tips & Tricks
 Grab all logs for entire StackStorm cluster with dependent services in Helm release:
 ```

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ For example:
 ```
 Don't forget running Helm upgrade to apply new changes.
 
-NOTE: `st2.packs.configs` will be ignored if you use `st2packs` images with `volumes.configs` (optional part of Method 2, described below).
+NOTE: On `helm upgrade` any configs in `st2.packs.configs` will overwrite the contents of `st2.packs.volumes.configs` (optional part of Method 2, described below).
 
 #### Pull st2packs from a private Docker registry
 If you need to pull your custom packs Docker image from a private repository, create a Kubernetes Docker registry secret and pass it to Helm values.
@@ -227,7 +227,7 @@ kubectl create secret docker-registry st2packs-auth --docker-server=<your-regist
 Once secret created, reference its name in helm value: `st2.packs.images[].pullSecret`.
 
 ### Method 2: Shared Volumes
-This method requires cluster-specific storage setup and configuration. As the storage volumes are both writable and shared, `st2 pack install` should work like it does for standalone StackStorm installations. The volumes get mounted at `/opt/stackstorm/{packs,virtualenvs}` in the containers that need read or write access to those directories. With this method, `/opt/stackstorm/configs` can also be mounted as a writable volume instead of using `st2.packs.configs`.
+This method requires cluster-specific storage setup and configuration. As the storage volumes are both writable and shared, `st2 pack install` should work like it does for standalone StackStorm installations. The volumes get mounted at `/opt/stackstorm/{packs,virtualenvs}` in the containers that need read or write access to those directories. With this method, `/opt/stackstorm/configs` can also be mounted as a writable volume (in which case the contents of `st2.packs.configs` takes precedence on `helm upgrade`).
 
 NOTE: With care, `st2packs` images can be used with `volumes`. Just make sure to keep the `st2packs` images up-to-date with any changes made via `st2 pack install`.
 If a pack is installed via an `st2packs` image and then it gets updated with `st2 pack install`, a subsequent `helm upgrade` will revert back to the version in the `st2packs` image.
@@ -269,7 +269,7 @@ You may either use the `st2.packs.configs` section of Helm values (like Method 1
 or add another shared writable volume similar to `packs` and `virtualenvs`. This volume gets mounted
 to `/opt/stackstorm/configs` instead of the `st2.packs.config` values.
 
-NOTE: If you define a configs volume, anything in `st2.packs.configs` will NOT be visible to StackStorm.
+NOTE: If you define a configs volume and specify `st2.packs.configs`, anything in `st2.packs.configs` takes precdence during `helm upgrade`, overwriting config files already in the volume.
 
 For example, to use persistentVolumeClaims:
 ```

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -129,6 +129,25 @@ Create the name of the stackstorm-ha service account to use
   emptyDir: {}
   {{- end }}
 {{- end -}}
+{{- define "packs-volume-mounts" -}}
+  {{- if .Values.st2.packs.images }}
+- name: st2-packs-vol
+  mountPath: /opt/stackstorm/packs
+  readOnly: true
+- name: st2-virtualenvs-vol
+  mountPath: /opt/stackstorm/virtualenvs
+  readOnly: true
+  {{- end }}
+{{- end -}}
+# define this here as well to simplify comparison with packs-volume-mounts
+{{- define "packs-volume-mounts-for-register-job" -}}
+  {{- if .Values.st2.packs.images }}
+- name: st2-packs-vol
+  mountPath: /opt/stackstorm/packs
+- name: st2-virtualenvs-vol
+  mountPath: /opt/stackstorm/virtualenvs
+  {{- end }}
+{{- end -}}
 
 # For custom st2packs-initContainers reduce duplicity by defining them here once
 # Merge packs and virtualenvs from st2 with those from st2packs images

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -122,9 +122,14 @@ Create the name of the stackstorm-ha service account to use
 
 # consolidate pack-configs-volumes definitions
 {{- define "pack-configs-volume" -}}
+  {{- if and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs }}
+- name: st2-pack-configs-vol
+{{ toYaml .Values.st2.packs.volumes.configs | indent 2 }}
+  {{- else }}
 - name: st2-pack-configs-vol
   configMap:
     name: {{ .Release.Name }}-st2-pack-configs
+  {{- end }}
 {{- end -}}
 {{- define "pack-configs-volume-mount" -}}
 - name: st2-pack-configs-vol

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -120,6 +120,17 @@ Create the name of the stackstorm-ha service account to use
   {{- end }}
 {{- end -}}
 
+# consolidate pack-configs-volumes definitions
+{{- define "pack-configs-volume" -}}
+- name: st2-pack-configs-vol
+  configMap:
+    name: {{ .Release.Name }}-st2-pack-configs
+{{- end -}}
+{{- define "pack-configs-volume-mount" -}}
+- name: st2-pack-configs-vol
+  mountPath: /opt/stackstorm/configs/
+{{- end -}}
+
 # For custom st2packs-Container reduce duplicity by defining it here once
 {{- define "packs-volumes" -}}
   {{- if .Values.st2.packs.images }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -127,6 +127,11 @@ Create the name of the stackstorm-ha service account to use
   emptyDir: {}
 - name: st2-virtualenvs-vol
   emptyDir: {}
+  {{- else if .Values.st2.packs.volumes.enabled }}
+- name: st2-packs-vol
+{{ toYaml .Values.st2.packs.volumes.packs | indent 2 }}
+- name: st2-virtualenvs-vol
+{{ toYaml .Values.st2.packs.volumes.virtualenvs | indent 2 }}
   {{- end }}
 {{- end -}}
 {{- define "packs-volume-mounts" -}}
@@ -137,11 +142,16 @@ Create the name of the stackstorm-ha service account to use
 - name: st2-virtualenvs-vol
   mountPath: /opt/stackstorm/virtualenvs
   readOnly: true
+  {{- else if .Values.st2.packs.volumes.enabled }}
+- name: st2-packs-vol
+  mountPath: /opt/stackstorm/packs
+- name: st2-virtualenvs-vol
+  mountPath: /opt/stackstorm/virtualenvs
   {{- end }}
 {{- end -}}
 # define this here as well to simplify comparison with packs-volume-mounts
 {{- define "packs-volume-mounts-for-register-job" -}}
-  {{- if .Values.st2.packs.images }}
+  {{- if or .Values.st2.packs.images .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
   mountPath: /opt/stackstorm/packs
 - name: st2-virtualenvs-vol

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -236,7 +236,7 @@ Create the name of the stackstorm-ha service account to use
     - 'sh'
     - '-ec'
     - |
-      /bin/cp -aR /opt/stackstorm/configs/. /opt/stackstorm/configs-shared &&
+      /bin/cp -aR /opt/stackstorm/configs/. /opt/stackstorm/configs-shared
   {{- end }}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -195,6 +195,8 @@ Create the name of the stackstorm-ha service account to use
       /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
       /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
     {{- end }}
+  {{- end }}
+  {{- if or $.Values.st2.packs.images $.Values.st2.packs.volumes.enabled }}
 # System packs
 - name: st2-system-packs
   image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -138,31 +138,31 @@ Create the name of the stackstorm-ha service account to use
 
 # For custom st2packs-Container reduce duplicity by defining it here once
 {{- define "packs-volumes" -}}
-  {{- if .Values.st2.packs.images }}
-- name: st2-packs-vol
-  emptyDir: {}
-- name: st2-virtualenvs-vol
-  emptyDir: {}
-  {{- else if .Values.st2.packs.volumes.enabled }}
+  {{- if .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
 {{ toYaml .Values.st2.packs.volumes.packs | indent 2 }}
 - name: st2-virtualenvs-vol
 {{ toYaml .Values.st2.packs.volumes.virtualenvs | indent 2 }}
+  {{- else if .Values.st2.packs.images }}
+- name: st2-packs-vol
+  emptyDir: {}
+- name: st2-virtualenvs-vol
+  emptyDir: {}
   {{- end }}
 {{- end -}}
 {{- define "packs-volume-mounts" -}}
-  {{- if .Values.st2.packs.images }}
+  {{- if .Values.st2.packs.volumes.enabled }}
+- name: st2-packs-vol
+  mountPath: /opt/stackstorm/packs
+- name: st2-virtualenvs-vol
+  mountPath: /opt/stackstorm/virtualenvs
+  {{- else if .Values.st2.packs.images }}
 - name: st2-packs-vol
   mountPath: /opt/stackstorm/packs
   readOnly: true
 - name: st2-virtualenvs-vol
   mountPath: /opt/stackstorm/virtualenvs
   readOnly: true
-  {{- else if .Values.st2.packs.volumes.enabled }}
-- name: st2-packs-vol
-  mountPath: /opt/stackstorm/packs
-- name: st2-virtualenvs-vol
-  mountPath: /opt/stackstorm/virtualenvs
   {{- end }}
 {{- end -}}
 # define this here as well to simplify comparison with packs-volume-mounts

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -124,12 +124,12 @@ Create the name of the stackstorm-ha service account to use
 {{- define "pack-configs-volume" -}}
   {{- if and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs }}
 - name: st2-pack-configs-vol
-{{ toYaml .Values.st2.packs.volumes.configs | indent 2 }}
-    {{- if .Values.st2.packs.configs }}
+  {{- toYaml .Values.st2.packs.volumes.configs | nindent 2 }}
+  {{-   if .Values.st2.packs.configs }}
 - name: st2-pack-configs-from-helm-vol
   configMap:
     name: {{ .Release.Name }}-st2-pack-configs
-    {{- end }}
+  {{-   end }}
   {{- else }}
 - name: st2-pack-configs-vol
   configMap:
@@ -149,9 +149,9 @@ Create the name of the stackstorm-ha service account to use
 {{- define "packs-volumes" -}}
   {{- if .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
-{{ toYaml .Values.st2.packs.volumes.packs | indent 2 }}
+  {{- toYaml .Values.st2.packs.volumes.packs | nindent 2 }}
 - name: st2-virtualenvs-vol
-{{ toYaml .Values.st2.packs.volumes.virtualenvs | indent 2 }}
+  {{- toYaml .Values.st2.packs.volumes.virtualenvs | nindent 2 }}
   {{- else if .Values.st2.packs.images }}
 - name: st2-packs-vol
   emptyDir: {}

--- a/templates/configmaps_packs.yaml
+++ b/templates/configmaps_packs.yaml
@@ -1,3 +1,4 @@
+{{- if not (and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs) -}}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -14,3 +15,4 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
 {{ toYaml .Values.st2.packs.configs | indent 2 }}
+{{- end -}}

--- a/templates/configmaps_packs.yaml
+++ b/templates/configmaps_packs.yaml
@@ -1,11 +1,10 @@
-{{- if not (and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs) -}}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ .Release.Name }}-st2-pack-configs
   annotations:
-    description: Custom StackStorm pack configs, shipped in '/opt/stackstorm/configs/'
+    description: StackStorm pack configs defined in helm values, shipped in (or copied to) '/opt/stackstorm/configs/'
   labels:
     app: st2
     tier: backend
@@ -15,4 +14,3 @@ metadata:
     heritage: {{ .Release.Service }}
 data:
 {{ toYaml .Values.st2.packs.configs | indent 2 }}
-{{- end -}}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -2,6 +2,14 @@
 {{- if and .Values.st2.packs.image }}
 {{- fail "Value st2.packs.image was renamed to st2.packs.images and is now a list of images" }}
 {{- end }}
+{{- if .Values.st2.packs.volumes.enabled }}
+  {{- if .Values.st2.packs.images }}
+{{- fail "st2.packs.images is not compatible with st2.packs.volumes.enabled. Please use only one method for setting up packs directories." }}
+  {{- end }}
+  {{- if not (and .Values.st2.packs.volumes.packs .Values.st2.packs.volumes.virtualenvs) }}
+{{- fail "Volume definition(s) missing! When st2.packs.volumes.enabled, you must define volumes for both packs and virtualenvs." }}
+  {{- end }}
+{{- end }}
 
 ---
 apiVersion: apps/v1

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1433,8 +1433,6 @@ spec:
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
         {{- end }}
-        - name: st2-pack-configs-vol
-          mountPath: /opt/stackstorm/configs/
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
@@ -1445,6 +1443,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
+        {{- include "pack-configs-volume-mount" . | nindent 8 }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
           subPath: post-start.sh
@@ -1481,9 +1480,6 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
         {{- end }}
-        - name: st2-pack-configs-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-pack-configs
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
@@ -1496,6 +1492,7 @@ spec:
               # 0400 file permission
               mode: 256
         {{- include "packs-volumes" . | nindent 8 }}
+        {{- include "pack-configs-volume" . | nindent 8 }}
         - name: st2-post-start-script-vol
           configMap:
             name: {{ .Release.Name }}-st2client-post-start-script

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -200,14 +200,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs
-          readOnly: true
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs
-          readOnly: true
-        {{- end }}
+        {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2api.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -232,9 +225,7 @@ spec:
               path: datastore_key.json
         {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
-        {{- if .Values.st2.packs.images }}
-{{- include "packs-volumes" . | indent 8 }}
-        {{- end }}
+        {{- include "packs-volumes" . | nindent 8 }}
         {{- if .Values.st2api.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1064,14 +1055,7 @@ spec:
             name: {{ $.Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" $ | nindent 8 }}
-        {{- if $.Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs
-          readOnly: true
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs
-          readOnly: true
-        {{- end }}
+        {{- include "packs-volume-mounts" $ | nindent 8 }}
         {{- if $.Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1101,9 +1085,7 @@ spec:
               path: datastore_key.json
         {{- end }}
         {{- include "st2-config-volume" $ | nindent 8 }}
-        {{- if $.Values.st2.packs.images }}
-{{- include "packs-volumes" $ | indent 8 }}
-        {{- end }}
+        {{- include "packs-volumes" $ | nindent 8 }}
         {{- if $.Values.st2sensorcontainer.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1203,14 +1185,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs
-          readOnly: true
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs
-          readOnly: true
-        {{- end }}
+        {{- include "packs-volume-mounts" . | nindent 8 }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
           subPath: post-start.sh
@@ -1241,9 +1216,7 @@ spec:
               path: {{ tpl .Values.st2.system_user.ssh_key_file . | base }}
               # 0400 file permission
               mode: 256
-        {{- if .Values.st2.packs.images }}
-{{- include "packs-volumes" . | indent 8 }}
-        {{- end }}
+        {{- include "packs-volumes" . | nindent 8 }}
         - name: st2-post-start-script-vol
           configMap:
             name: {{ .Release.Name }}-st2actionrunner-post-start-script
@@ -1471,14 +1444,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs
-          readOnly: true
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs
-          readOnly: true
-        {{- end }}
+        {{- include "packs-volume-mounts" . | nindent 8 }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
           subPath: post-start.sh
@@ -1529,9 +1495,7 @@ spec:
               path: {{ tpl .Values.st2.system_user.ssh_key_file . | base }}
               # 0400 file permission
               mode: 256
-        {{- if .Values.st2.packs.images }}
-{{- include "packs-volumes" . | indent 8 }}
-        {{- end }}
+        {{- include "packs-volumes" . | nindent 8 }}
         - name: st2-post-start-script-vol
           configMap:
             name: {{ .Release.Name }}-st2client-post-start-script

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -201,6 +201,9 @@ spec:
           readOnly: true
         {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2.packs.volumes.enabled }}
+          {{- include "pack-configs-volume-mount" . | nindent 8 }}
+        {{- end }}
         {{- if .Values.st2api.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -226,6 +229,9 @@ spec:
         {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         {{- include "packs-volumes" . | nindent 8 }}
+        {{- if .Values.st2.packs.volumes.enabled }}
+          {{- include "pack-configs-volume" . | nindent 8 }}
+        {{- end }}
         {{- if .Values.st2api.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1186,6 +1192,9 @@ spec:
           readOnly: true
         {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2.packs.volumes.enabled }}
+          {{- include "pack-configs-volume-mount" . | nindent 8 }}
+        {{- end }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
           subPath: post-start.sh
@@ -1217,6 +1226,9 @@ spec:
               # 0400 file permission
               mode: 256
         {{- include "packs-volumes" . | nindent 8 }}
+        {{- if .Values.st2.packs.volumes.enabled }}
+          {{- include "pack-configs-volume" . | nindent 8 }}
+        {{- end }}
         - name: st2-post-start-script-vol
           configMap:
             name: {{ .Release.Name }}-st2actionrunner-post-start-script

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -3,9 +3,6 @@
 {{- fail "Value st2.packs.image was renamed to st2.packs.images and is now a list of images" }}
 {{- end }}
 {{- if .Values.st2.packs.volumes.enabled }}
-  {{- if .Values.st2.packs.images }}
-{{- fail "st2.packs.images is not compatible with st2.packs.volumes.enabled. Please use only one method for setting up packs directories." }}
-  {{- end }}
   {{- if not (and .Values.st2.packs.volumes.packs .Values.st2.packs.volumes.virtualenvs) }}
 {{- fail "Volume definition(s) missing! When st2.packs.volumes.enabled, you must define volumes for both packs and virtualenvs." }}
   {{- end }}
@@ -186,7 +183,7 @@ spec:
       initContainers:
       {{- include "init-containers-wait-for-db" . | nindent 6 }}
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
-      {{- if .Values.st2.packs.images }}
+      {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
         {{- include "packs-initContainers" . | nindent 6 }}
       {{- end }}
       containers:
@@ -1039,7 +1036,7 @@ spec:
       initContainers:
       {{- include "init-containers-wait-for-db" $ | nindent 6 }}
       {{- include "init-containers-wait-for-mq" $ | nindent 6 }}
-      {{- if $.Values.st2.packs.images }}
+      {{- if and $.Values.st2.packs.images (not $.Values.st2.packs.volumes.enabled) }}
         {{- include "packs-initContainers" $ | nindent 6 }}
       {{- end }}
       containers:
@@ -1177,7 +1174,7 @@ spec:
       initContainers:
       {{- include "init-containers-wait-for-db" . | nindent 6 }}
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
-      {{- if .Values.st2.packs.images }}
+      {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
         {{- include "packs-initContainers" . | nindent 6 }}
       {{- end }}
       containers:
@@ -1399,7 +1396,7 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- if .Values.st2.packs.images }}
+      {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
         {{- include "packs-initContainers" . | nindent 6 }}
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -374,9 +374,7 @@ spec:
       {{- end }}
       initContainers:
       {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- if $.Values.st2.packs.images -}}
-        {{- include "packs-initContainers" . | nindent 6 }}
-      {{ end }}
+      {{- include "packs-initContainers" . | nindent 6 }}
       {{- if $.Values.jobs.preRegisterContentCommand }}
       - name: st2-register-content-custom-init
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -406,17 +406,14 @@ spec:
           - --register-fail-on-failure
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        - name: st2-pack-configs-vol
-          mountPath: /opt/stackstorm/configs/
         {{- include "packs-volume-mounts-for-register-job" . | nindent 8 }}
+        {{- include "pack-configs-volume-mount" . | nindent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
-        - name: st2-pack-configs-vol
-          configMap:
-            name: {{ .Release.Name }}-st2-pack-configs
-        {{- include "packs-volumes" $ | nindent 8 }}
+        {{- include "packs-volumes" . | nindent 8 }}
+        {{- include "pack-configs-volume" . | nindent 8 }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -408,12 +408,7 @@ spec:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-pack-configs-vol
           mountPath: /opt/stackstorm/configs/
-        {{- if .Values.st2.packs.images }}
-        - name: st2-packs-vol
-          mountPath: /opt/stackstorm/packs/
-        - name: st2-virtualenvs-vol
-          mountPath: /opt/stackstorm/virtualenvs/
-        {{- end }}
+        {{- include "packs-volume-mounts-for-register-job" . | nindent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:

--- a/values.yaml
+++ b/values.yaml
@@ -94,7 +94,7 @@ st2:
     # E.g. having all desired StackStorm-Exchange packs in one image and several custom packs in additional images
     #
     # This must be empty if st2.packs.volumes is enabled.
-    images: {}
+    images: []
       #- repository: index.docker.io/stackstorm
       #  name: st2packs
       #  tag: example

--- a/values.yaml
+++ b/values.yaml
@@ -92,8 +92,6 @@ st2:
     # For each given st2packs container you can define repository, name, tag and pullPolicy for this image below.
     # Multiple pack images can help when dealing with frequent updates by only rebuilding smaller images for desired packs
     # E.g. having all desired StackStorm-Exchange packs in one image and several custom packs in additional images
-    #
-    # This must be empty if st2.packs.volumes is enabled.
     images: []
       #- repository: index.docker.io/stackstorm
       #  name: st2packs
@@ -104,15 +102,14 @@ st2:
 
     # Custom packs volumes definitions.
     #
-    # Use this instead of st2.packs.images to have StackStorm use persistent/shared/writable storage configured
-    # previously in your cluster. The choice of storage solution is cluster-dependent (it changes besed on where the
-    # cluster is hosted and which storage solutions are available in your cluster).
+    # Use this to have StackStorm use persistent/shared/writable storage configured previously in your cluster.
+    # The choice of storage solution is cluster-dependent (it changes besed on where the cluster is hosted
+    # and which storage solutions are available in your cluster).
     #
     # To use this, set enabled to true, and add cluster-specific volume definitions for at least packs and virtualenvs below.
     # Please consult the documentation for your cluster's storage solution.
     # Some generic examples are listed under st2.packs.volumes.packs below.
     volumes:
-      # to enable st2.packs.volumes, st2.packs.images must not be empty
       enabled: false
 
       packs: {}

--- a/values.yaml
+++ b/values.yaml
@@ -73,9 +73,11 @@ st2:
 
   # Custom pack configs and image settings.
   #
-  # By default, system packs are available. However, since 'st2 pack install' cannot be run in the k8s cluster,
-  # you will need to bake additional packs into an 'st2packs' image. Please see github.com/stackstorm/stackstorm-ha/README.md
+  # By default, system packs are available. By default, however, `st2 pack install` cannot be run in the k8s cluster,
+  # so you will need to bake additional packs into an 'st2packs' image. Please see github.com/stackstorm/stackstorm-ha/README.md
   # for details on how to build this image.
+  # To change this default, and use persistent/shared/writable storage that is available in your cluster, you need to
+  # enable st2.packs.volumes below, adding volume definitions customized for use your cluster's storage provider.
   packs:
     # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
     # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file
@@ -85,9 +87,12 @@ st2:
         # example core pack config yaml
 
     # Custom packs images settings.
+    #
     # For each given st2packs container you can define repository, name, tag and pullPolicy for this image below.
     # Multiple pack images can help when dealing with frequent updates by only rebuilding smaller images for desired packs
     # E.g. having all desired StackStorm-Exchange packs in one image and several custom packs in additional images
+    #
+    # This must be empty if st2.packs.volumes is enabled.
     images:
       #- repository: index.docker.io/stackstorm
       #  name: st2packs
@@ -95,6 +100,47 @@ st2:
       #  pullPolicy: IfNotPresent
       # Optional name of the imagePullSecret if your custom packs image is hosted by a private Docker registry
       #  pullSecret: st2packs-auth
+
+    # Custom packs volumes definitions.
+    #
+    # Use this instead of st2.packs.images to have StackStorm use persistent/shared/writable storage configured
+    # previously in your cluster. The choice of storage solution is cluster-dependent (it changes besed on where the
+    # cluster is hosted and which storage solutions are available in your cluster).
+    #
+    # To use this, set enabled to true, and add cluster-specific volume definitions for at least packs and virtualenvs below.
+    # Please consult the documentation for your cluster's storage solution.
+    # Some generic examples are listed under st2.packs.volumes.packs below.
+    volumes:
+      # to enable st2.packs.volumes, st2.packs.images must not be empty
+      enabled: false
+
+      packs: # mounted to /opt/stackstorm/packs
+        # packs volume definition is required if st2.packs.volumes is enabled
+
+        # example using persistentVolumeClaim:
+        #persistentVolumeClaim:
+        #  claim-name: pvc-st2-packs
+
+        # example using NFS:
+        #nfs:
+        #  server: "10.12.34.56"
+        #  path: /var/nfsshare/packs
+
+        # example using a flexVolume + rook-ceph
+        #flexVolume:
+        #  driver: ceph.rook.io/rook
+        #  options:
+        #    fsName: fs1
+        #    clusterNamespace: rook-ceph
+        #    path: /st2/packs
+
+      virtualenvs: # mounted to /opt/stackstorm/virtualenvs
+        # virtualenvs volume definition is required if st2.packs.volumes is enabled
+        # see the examples under st2.packs.volumes.packs
+
+      configs: # mounted to /opt/stackstorm/configs
+        # configs volume definition is optional, but only used if st2.packs.volumes is enabled
+        # see the examples under st2.packs.volumes.packs
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.

--- a/values.yaml
+++ b/values.yaml
@@ -94,7 +94,7 @@ st2:
     # E.g. having all desired StackStorm-Exchange packs in one image and several custom packs in additional images
     #
     # This must be empty if st2.packs.volumes is enabled.
-    images:
+    images: {}
       #- repository: index.docker.io/stackstorm
       #  name: st2packs
       #  tag: example
@@ -115,7 +115,8 @@ st2:
       # to enable st2.packs.volumes, st2.packs.images must not be empty
       enabled: false
 
-      packs: # mounted to /opt/stackstorm/packs
+      packs: {}
+        # mounted to /opt/stackstorm/packs
         # packs volume definition is required if st2.packs.volumes is enabled
 
         # example using persistentVolumeClaim:
@@ -135,11 +136,13 @@ st2:
         #    clusterNamespace: rook-ceph
         #    path: /st2/packs
 
-      virtualenvs: # mounted to /opt/stackstorm/virtualenvs
+      virtualenvs: {}
+        # mounted to /opt/stackstorm/virtualenvs
         # virtualenvs volume definition is required if st2.packs.volumes is enabled
         # see the examples under st2.packs.volumes.packs
 
-      configs: # mounted to /opt/stackstorm/configs
+      configs: {}
+        # mounted to /opt/stackstorm/configs
         # configs volume definition is optional, but only used if st2.packs.volumes is enabled
         # see the examples under st2.packs.volumes.packs
 

--- a/values.yaml
+++ b/values.yaml
@@ -81,6 +81,7 @@ st2:
   packs:
     # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
     # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file
+    # NOTE: This is ignored if st2.packs.volumes.configs is defined and st2.packs.volumes is enabled
     configs:
       core.yaml: |
         ---

--- a/values.yaml
+++ b/values.yaml
@@ -81,7 +81,7 @@ st2:
   packs:
     # Custom StackStorm pack configs. Each record creates a file in '/opt/stackstorm/configs/'
     # https://docs.stackstorm.com/reference/pack_configs.html#configuration-file
-    # NOTE: This is ignored if st2.packs.volumes.configs is defined and st2.packs.volumes is enabled
+    # NOTE: This takes precedence over the contents of st2.packs.volumes.configs (if defined) on helm upgrade.
     configs:
       core.yaml: |
         ---
@@ -141,6 +141,7 @@ st2:
       configs: {}
         # mounted to /opt/stackstorm/configs
         # configs volume definition is optional, but only used if st2.packs.volumes is enabled
+        # Anything in `st2.packs.configs` will be added to this volume automatically on helm install/upgrade.
         # see the examples under st2.packs.volumes.packs
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer

--- a/values.yaml
+++ b/values.yaml
@@ -128,6 +128,7 @@ st2:
         # example using a flexVolume + rook-ceph
         #flexVolume:
         #  driver: ceph.rook.io/rook
+        #  fsType: ceph
         #  options:
         #    fsName: fs1
         #    clusterNamespace: rook-ceph


### PR DESCRIPTION
New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`.

For a good description of the thinking behind this PR see: https://github.com/StackStorm/stackstorm-ha/issues/18#issuecomment-862837916 (and the rest of the comments in that issue)

- add `st2.packs.volumes` section to values.yaml
- consolidate packs-volume-mounts into templates
- add `st2.packs.volumes` definitions to packs-volumes templates
- consolidate pack-configs-volume into templates
- add pack-configs-volume to more pods when `st2.packs.volumes.enabled`
- add error messages if `st2.packs.volumes` config is incomplete
- When `st2.packs.volumes.enabled`, make register-content packs-initContainer include system packs
- disable `packs.configs` ConfigMap if it is not needed/used
- add instructions for `st2.packs.volumes` values
- add `st2.packs.volumes` caveats similar to those documented in #118
- allow using `st2.packs.volumes` with `st2.packs.images`
- Allow `st2.packs.configs` to work with `st2.packs.volumes.configs`
- add changelog entry

Related #160

Resolves #18
Closes #118
