### PR TITLE
Add custom image.tag for all pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Add optional imagePullSecrets to ServiceAccount using `serviceAccount.pullSecret` from values.yaml. If pods do not have imagePullSecrets (eg without `image.pullSecret` in values.yaml), k8s populates them from the ServiceAccount. (#196) (by @cognifloyd)
 * Reformat some yaml strings so that single quotes wrap strings that include double quotes (#194) (by @cognifloyd)
 * st2chatops change: If `st2chatops.env.ST2_API_KEY` is defined, do not set `ST2_AUTH_USERNAME` or `ST2_AUTH_PASSWORD` env vars any more. (#197) (by @cognifloyd)
-
+* Add image.tag overrides for all deployments. (#200) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1213,7 +1213,7 @@ spec:
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
         - configMapRef:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -45,7 +45,7 @@ spec:
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       - name: generate-htpasswd
-        image: '{{ template "imageRepository" . }}/st2auth:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: ST2_AUTH_USERNAME
@@ -67,7 +67,7 @@ spec:
           - printf "${ST2_AUTH_USERNAME}:$(openssl passwd -apr1 "${ST2_AUTH_PASSWORD}")\n" > /tmp/st2/htpasswd
       containers:
       - name: st2auth
-        image: '{{ template "imageRepository" . }}/st2auth:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9100
@@ -161,7 +161,7 @@ spec:
       {{- end }}
       containers:
       - name: st2api
-        image: '{{ template "imageRepository" . }}/st2api:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9101
@@ -265,7 +265,7 @@ spec:
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2stream
-        image: '{{ template "imageRepository" . }}/st2stream:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 9102
@@ -340,7 +340,7 @@ spec:
       {{- end }}
       containers:
       - name: st2web
-        image: '{{ template "imageRepository" . }}/st2web:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: 80
@@ -441,7 +441,7 @@ spec:
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2rulesengine
-        image: '{{ template "imageRepository" . }}/st2rulesengine:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -528,7 +528,7 @@ spec:
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2timersengine
-        image: '{{ template "imageRepository" . }}/st2timersengine:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -607,7 +607,7 @@ spec:
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2workflowengine
-        image: '{{ template "imageRepository" . }}/st2workflowengine:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -698,7 +698,7 @@ spec:
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2scheduler
-        image: '{{ template "imageRepository" . }}/st2scheduler:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -789,7 +789,7 @@ spec:
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2notifier
-        image: '{{ template "imageRepository" . }}/st2notifier:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -881,7 +881,7 @@ spec:
       {{- end }}
       containers:
       - name: st2sensorcontainer{{ template "hyphenPrefix" .name }}
-        image: '{{ template "imageRepository" $ }}/st2sensorcontainer:{{ $.Chart.AppVersion }}'
+        image: '{{ template "imageRepository" $ }}/st2sensorcontainer:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with .readinessProbe }}
         # Probe to check if app is running. Failure will lead to a pod restart.
@@ -1015,7 +1015,7 @@ spec:
       {{- end }}
       containers:
       - name: st2actionrunner
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -1128,7 +1128,7 @@ spec:
       {{ include "init-containers-wait-for-mq" . | indent 6 }}
       containers:
       - name: st2garbagecollector
-        image: '{{ template "imageRepository" . }}/st2garbagecollector:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
@@ -1213,7 +1213,7 @@ spec:
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
         - configMapRef:
@@ -1244,7 +1244,7 @@ spec:
             EOT
       containers:
       - name: st2client
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         env:
         - name: ST2CLIENT
@@ -1374,7 +1374,7 @@ spec:
       {{- end }}
       containers:
       - name: st2chatops
-        image: '{{ .Values.st2chatops.image.repository | default "stackstorm" }}/{{ .Values.st2chatops.image.name | default "st2chatops" }}:{{ tpl (.Values.st2chatops.image.tag | default .Chart.AppVersion) . }}'
+        image: '{{ .Values.st2chatops.image.repository | default "stackstorm" }}/{{ .Values.st2chatops.image.name | default "st2chatops" }}:{{ tpl (.Values.st2chatops.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.st2chatops.image.pullPolicy | default .Values.image.pullPolicy }}
         {{- if not (hasKey .Values.st2chatops.env "ST2_API_KEY") }}
         env:

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -37,7 +37,7 @@ spec:
       {{- end }}
       containers:
       - name: st2-apply-rbac-definitions
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - st2-apply-rbac-definitions
@@ -125,7 +125,7 @@ spec:
             done
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
         - configMapRef:
@@ -156,7 +156,7 @@ spec:
             EOT
       containers:
       - name: st2-apikey-load
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - st2
@@ -223,7 +223,7 @@ spec:
       {{ include "init-containers-wait-for-db" . | indent 6 }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         envFrom:
         - configMapRef:
@@ -254,7 +254,7 @@ spec:
             EOT
       containers:
       - name: st2-key-load
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - st2
@@ -336,7 +336,7 @@ spec:
       {{ end }}
       containers:
       - name: st2-register-content
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
           - st2-register-content

--- a/values.yaml
+++ b/values.yaml
@@ -506,6 +506,15 @@ st2chatops:
     attach: false
 
 ##
+## Various batch jobs (apply-rbac-definitions, apikey-load, key-load, register-content)
+##
+jobs:
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
+
+##
 ## MongoDB HA configuration (3rd party chart dependency)
 ##
 ## For values.yaml reference:

--- a/values.yaml
+++ b/values.yaml
@@ -12,6 +12,9 @@ image:
   # st2chatops and st2packs (which have their own override). This also does not impact 
   # dependencies such as mongo or redis, which have their own helm chart settings.
   repository: ""
+  # st2 image tag - defaults to AppVersion.
+  # Note that Helm templating is supported in this block!
+  tag: "{{ .Chart.AppVersion }}"
   # Image pull secret.
   # May be required for public docker hub due to rate limiting or any private repository.
   # See: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
@@ -84,6 +87,10 @@ st2:
           requests:
             memory: "100Mi"
             cpu: "50m"
+        # Override default image settings (for now, only tag can be overridden)
+        image: {}
+          ## Note that Helm templating is supported in this block!
+          #tag: "{{ .Values.image.tag }}"
         # Additional advanced settings to control pod/deployment placement
         affinity: {}
         nodeSelector: {}
@@ -235,6 +242,10 @@ st2web:
       cpu: "50m"
     limits:
       memory: "100Mi"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # TODO: Add Ingress setting as a way to expose service to public (#6).
   # ingress:
   service:
@@ -263,6 +274,10 @@ st2auth:
     requests:
       memory: "85Mi"
       cpu: "50m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -277,6 +292,10 @@ st2api:
     requests:
       memory: "150Mi"
       cpu: "25m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -291,6 +310,10 @@ st2stream:
     requests:
       memory: "100Mi"
       cpu: "50m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -305,6 +328,10 @@ st2rulesengine:
     requests:
       memory: "75Mi"
       cpu: "25m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -318,6 +345,10 @@ st2timersengine:
     requests:
       memory: "75Mi"
       cpu: "10m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -332,6 +363,10 @@ st2workflowengine:
     requests:
       memory: "200Mi"
       cpu: "100m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -346,6 +381,10 @@ st2scheduler:
     requests:
       memory: "75Mi"
       cpu: "50m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -360,6 +399,10 @@ st2notifier:
     requests:
       memory: "75Mi"
       cpu: "50m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -375,6 +418,10 @@ st2actionrunner:
     requests:
       memory: "200Mi"
       cpu: "75m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   annotations: {}
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
@@ -392,6 +439,14 @@ st2actionrunner:
   serviceAccount:
     attach: false
 
+# The st2client deployment/pod simplifies ad-hoc administration.
+# st2client is a special purpose actionrunner pod, but you can customize it separately
+st2client:
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
+
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.
 # By default this process does nothing and needs to be setup in st2.conf to perform any work.
@@ -402,6 +457,10 @@ st2garbagecollector:
     requests:
       memory: "80Mi"
       cpu: "10m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []
@@ -431,7 +490,7 @@ st2chatops:
     #repository: stackstorm
     #name: st2chatops
     ## Note that Helm templating is supported in this block!
-    #tag: "{{ .Chart.AppVersion }}"
+    #tag: "{{ .Values.image.tag }}"
     #pullPolicy: IfNotPresent
   # Tested requested resource consumption for st2chatops & hubot in normal mode
   # Please adjust based on your conscious choice


### PR DESCRIPTION
This adds an image.tag value for each of the pods.

Partially implements #132 (this only adds custom image.tag, not image.repository).

- add image.tag overrides for all deployments
- add image.tag overrides for all jobs
