### PR TITLE
Allow adding postStartScript lifecycle hook to all deployments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Move st2-config-vol volume definition and list of st2-config-vol volumeMounts to helpers to reduce duplication (#198) (by @cognifloyd)
 * Fix permissions for /home/stanley/.ssh/stanley_rsa using the postStart lifecycle hook (#219) (by @cognifloyd)
 * Make system_user configurable when using custom st2actionrunner images that do not provide stanley (#220) (by @cognifloyd)
+* Allow providing scripts in values for use in lifecycle postStart hooks of all deployments. (#206) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/configmaps_post-start-script.yaml
+++ b/templates/configmaps_post-start-script.yaml
@@ -1,10 +1,12 @@
+{{- range tuple "st2auth" "st2api" "st2stream" "st2web" "st2rulesengine" "st2timersengine" "st2workflowengine" "st2scheduler" "st2notifier" "st2sensorcontainer" "st2actionrunner" "st2garbagecollector" "st2client" "st2chatops" -}}
+  {{- if or (index $.Values . "postStartScript") (eq . "st2actionrunner") (eq . "st2client") }}
 ---
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ $.Release.Name }}-st2actionrunner-post-start-script
+  name: {{ $.Release.Name }}-{{ . }}-post-start-script
   annotations:
-    description: Custom postStart lifecycle event handler script for st2actionrunner
+    description: Custom postStart lifecycle event handler script for {{ . }}
   labels:
     app: st2
     tier: backend
@@ -13,11 +15,12 @@ metadata:
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
 data:
-  # k8s calls this script in parallel with starting st2actionrunner (ie the same time as ENTRYPOINT)
+  # k8s calls this script in parallel with starting {{ . }} (ie the same time as ENTRYPOINT)
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   post-start.sh: |
     #!/bin/bash
+    {{- if or (eq . "st2actionrunner") (eq . "st2client") }}
       {{- $system_user := $.Values.st2.system_user.user }}
       {{- $ssh_key_file := tpl $.Values.st2.system_user.ssh_key_file $ }}
       {{- $ssh_key_file_name := base $ssh_key_file }}
@@ -27,3 +30,8 @@ data:
     chown -R {{ $system_user }}:{{ $system_user }} {{ $ssh_key_file_dir }}
     chmod 400 {{ $ssh_key_file }}
     chmod 500 {{ $ssh_key_file_dir }}
+    {{- end }}
+    {{- index $.Values . "postStartScript" | nindent 4 }}
+
+  {{- end }}
+{{- end -}}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -35,6 +35,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
+        {{- if .Values.st2auth.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2auth.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2auth.annotations }}
           {{- toYaml .Values.st2auth.annotations | nindent 8 }}
         {{- end }}
@@ -158,6 +161,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- if .Values.st2api.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2api.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2api.annotations }}
           {{- toYaml .Values.st2api.annotations | nindent 8 }}
         {{- end }}
@@ -281,6 +287,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if .Values.st2stream.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2stream.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2stream.annotations }}
           {{- toYaml .Values.st2stream.annotations | nindent 8 }}
         {{- end }}
@@ -372,6 +381,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2web.yaml") . | sha256sum }}
+        {{- if .Values.st2web.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2web.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2web.annotations }}
           {{- toYaml .Values.st2web.annotations | nindent 8 }}
         {{- end }}
@@ -494,6 +506,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if .Values.st2rulesengine.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2rulesengine.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2rulesengine.annotations }}
           {{- toYaml .Values.st2rulesengine.annotations | nindent 8 }}
         {{- end }}
@@ -594,6 +609,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if .Values.st2timersengine.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2timersengine.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2timersengine.annotations }}
           {{- toYaml .Values.st2timersengine.annotations | nindent 8 }}
         {{- end }}
@@ -686,6 +704,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- if .Values.st2workflowengine.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2workflowengine.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2workflowengine.annotations }}
           {{- toYaml .Values.st2workflowengine.annotations | nindent 8 }}
         {{- end }}
@@ -790,6 +811,9 @@ spec:
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- if .Values.st2scheduler.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2scheduler.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2scheduler.annotations }}
           {{- toYaml .Values.st2scheduler.annotations | nindent 8 }}
         {{- end }}
@@ -894,6 +918,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if .Values.st2notifier.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2notifier.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2notifier.annotations }}
           {{- toYaml .Values.st2notifier.annotations | nindent 8 }}
         {{- end }}
@@ -990,6 +1017,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") $ | sha256sum }}
         checksum/packs: {{ include (print $.Template.BasePath "/configmaps_packs.yaml") $ | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") $ | sha256sum }}
+        {{- if $.Values.st2sensorcontainer.postStartScript }}
+        checksum/post-start-script: {{ $.Values.st2sensorcontainer.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .annotations }}
           {{- toYaml .annotations | nindent 8 }}
         {{- end }}
@@ -1130,6 +1160,9 @@ spec:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- if .Values.st2actionrunner.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2actionrunner.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2actionrunner.annotations }}
           {{- toYaml .Values.st2actionrunner.annotations | nindent 8 }}
         {{- end }}
@@ -1261,6 +1294,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmaps_st2-conf.yaml") . | sha256sum }}
+        {{- if .Values.st2garbagecollector.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2garbagecollector.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2garbagecollector.annotations }}
           {{- toYaml .Values.st2garbagecollector.annotations | nindent 8 }}
         {{- end }}
@@ -1355,6 +1391,9 @@ spec:
         checksum/auth: {{ include (print $.Template.BasePath "/secrets_st2auth.yaml") . | sha256sum }}
         checksum/ssh: {{ include (print $.Template.BasePath "/secrets_ssh.yaml") . | sha256sum }}
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") . | sha256sum }}
+        {{- if .Values.st2client.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2client.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2client.annotations }}
           {{- toYaml .Values.st2client.annotations | nindent 8 }}
         {{- end }}
@@ -1528,6 +1567,9 @@ spec:
         heritage: {{ .Release.Service }}
       annotations:
         checksum/chatops: {{ include (print $.Template.BasePath "/secrets_st2chatops.yaml") . | sha256sum }}
+        {{- if .Values.st2chatops.postStartScript }}
+        checksum/post-start-script: {{ .Values.st2chatops.postStartScript | sha256sum }}
+        {{- end }}
         {{- if .Values.st2chatops.annotations }}
           {{- toYaml .Values.st2chatops.annotations | nindent 8 }}
         {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -86,6 +86,15 @@ spec:
           mountPath: /etc/st2/htpasswd
           subPath: htpasswd
           readOnly: true
+        {{- if .Values.st2auth.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2auth.resources | nindent 10 }}
     {{- if .Values.st2auth.serviceAccount.attach }}
@@ -96,6 +105,11 @@ spec:
         - name: htpasswd-vol
           emptyDir:
             medium: Memory
+        {{- if .Values.st2auth.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2auth-post-start-script
+        {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -188,6 +202,15 @@ spec:
           mountPath: /opt/stackstorm/virtualenvs
           readOnly: true
         {{- end }}
+        {{- if .Values.st2api.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2api.resources | nindent 10 }}
     {{- if .Values.st2api.serviceAccount.attach }}
@@ -205,6 +228,11 @@ spec:
         {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2.packs.images }}
 {{- include "packs-volumes" . | indent 8 }}
+        {{- end }}
+        {{- if .Values.st2api.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2api-post-start-script
         {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -278,6 +306,15 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2stream.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2stream.resources | nindent 10 }}
     {{- if .Values.st2stream.serviceAccount.attach }}
@@ -285,6 +322,11 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
+        {{- if .Values.st2stream.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2stream-post-start-script
+        {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -366,27 +408,45 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
             optional: true
-    {{- if .Values.st2web.config }}
+    {{- if or .Values.st2web.config .Values.st2web.postStartScript }}
         volumeMounts:
-          - name: st2web-config-vol
-            mountPath: /opt/stackstorm/static/webui/config.js
-            subPath: st2web.config.js
     {{- else }}
         volumeMounts: []
     {{- end }}
+        {{- if .Values.st2web.config }}
+          - name: st2web-config-vol
+            mountPath: /opt/stackstorm/static/webui/config.js
+            subPath: st2web.config.js
+        {{- end }}
+        {{- if .Values.st2web.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2web.resources | nindent 10 }}
     {{- if .Values.st2web.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
-    {{- if .Values.st2web.config }}
+    {{- if or .Values.st2web.config .Values.st2web.postStartScript }}
       volumes:
-        - name: st2web-config-vol
-          configMap:
-            name: {{ .Release.Name }}-st2web-config
     {{- else }}
       volumes: []
     {{- end }}
+        {{- if .Values.st2web.config }}
+        - name: st2web-config-vol
+          configMap:
+            name: {{ .Release.Name }}-st2web-config
+        {{- end }}
+        {{- if .Values.st2web.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2web-post-start-script
+        {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -457,6 +517,15 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2rulesengine.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2rulesengine.resources | nindent 10 }}
     {{- if .Values.st2rulesengine.serviceAccount.attach }}
@@ -471,6 +540,11 @@ spec:
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
+        {{- if .Values.st2rulesengine.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2rulesengine-post-start-script
         {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -543,6 +617,15 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2timersengine.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2timersengine.resources | nindent 10 }}
     {{- if .Values.st2timersengine.serviceAccount.attach }}
@@ -550,6 +633,11 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
+        {{- if .Values.st2timersengine.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2timersengine-post-start-script
+        {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -626,6 +714,15 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
+        {{- if .Values.st2workflowengine.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2workflowengine.resources | nindent 10 }}
     {{- if .Values.st2workflowengine.serviceAccount.attach }}
@@ -640,6 +737,11 @@ spec:
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
+        {{- if .Values.st2workflowengine.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2workflowengine-post-start-script
         {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
@@ -716,6 +818,15 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
+        {{- if .Values.st2scheduler.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2scheduler.resources | nindent 10 }}
     {{- if .Values.st2scheduler.serviceAccount.attach }}
@@ -731,6 +842,11 @@ spec:
               path: datastore_key.json
         {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
+        {{- if .Values.st2scheduler.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2scheduler-post-start-script
+        {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -801,6 +917,15 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2notifier.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2notifier.resources | nindent 10 }}
     {{- if .Values.st2notifier.serviceAccount.attach }}
@@ -808,6 +933,11 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
+        {{- if .Values.st2notifier.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2notifier-post-start-script
+        {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -917,6 +1047,15 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
+        {{- if $.Values.st2sensorcontainer.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .resources | nindent 10 }}
     {{- if .serviceAccount.attach }}
@@ -934,6 +1073,11 @@ spec:
         {{- include "st2-config-volume" $ | nindent 8 }}
         {{- if $.Values.st2.packs.images }}
 {{- include "packs-volumes" $ | indent 8 }}
+        {{- end }}
+        {{- if $.Values.st2sensorcontainer.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ $.Release.Name }}-st2sensorcontainer-post-start-script
         {{- end }}
     {{- if $.Values.dnsPolicy }}
       dnsPolicy: {{ $.Values.dnsPolicy }}
@@ -1140,6 +1284,15 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2garbagecollector.postStartScript }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        {{- end }}
         resources:
           {{- toYaml .Values.st2garbagecollector.resources | nindent 10 }}
     {{- if .Values.st2garbagecollector.serviceAccount.attach }}
@@ -1147,6 +1300,11 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
+        {{- if .Values.st2garbagecollector.postStartScript }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2garbagecollector-post-start-script
+        {{- end }}
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -1337,7 +1495,7 @@ spec:
         {{- end }}
         - name: st2-post-start-script-vol
           configMap:
-            name: {{ .Release.Name }}-st2actionrunner-post-start-script
+            name: {{ .Release.Name }}-st2client-post-start-script
 
 {{ if .Values.st2chatops.enabled -}}
 ---
@@ -1413,6 +1571,20 @@ spec:
             port: 8081
           initialDelaySeconds: 10
           periodSeconds: 30
+        {{- if .Values.st2chatops.postStartScript }}
+        volumeMounts:
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        volumes:
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2chatops-post-start-script
+        {{- end }}
         resources:
           {{- toYaml .Values.st2chatops.resources | nindent 10 }}
     {{- if .Values.st2chatops.serviceAccount.attach }}

--- a/values.yaml
+++ b/values.yaml
@@ -122,6 +122,7 @@ st2:
         tolerations: []
         serviceAccount:
           attach: false
+        # note: postStartScript is not valid here. Use st2sensorcontainer.postStartScript instead.
   # Import data into StackStorm's Key/Value datastore (https://docs.stackstorm.com/datastore.html)
   keyvalue:
     #- name: st2_version
@@ -248,6 +249,11 @@ st2web:
   # See https://github.com/StackStorm/st2web#connecting-to-st2-server for more info
   # config: |
   #  // see https://github.com/StackStorm/st2web/blob/master/config.js
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2auth
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
 st2auth:
@@ -267,6 +273,11 @@ st2auth:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2api
 # Multiple st2api process can be behind a load balancer in an active-active configuration.
 st2api:
@@ -286,6 +297,11 @@ st2api:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2stream
 # Multiple st2stream process can be behind a load balancer in an active-active configuration.
 st2stream:
@@ -305,6 +321,11 @@ st2stream:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2rulesengine
 # Multiple st2rulesengine processes can run in active-active with only connections to MongoDB and RabbitMQ. All these will share the TriggerInstance load and naturally pick up more work if one or more of the processes becomes unavailable.
 st2rulesengine:
@@ -324,6 +345,11 @@ st2rulesengine:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2timersengine
 # Only single replica is created via K8s Deployment as timersengine can't work in active-active mode at the moment and it relies on K8s failover/reschedule capabilities to address cases of process failure.
 st2timersengine:
@@ -342,6 +368,11 @@ st2timersengine:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2workflowengine
 # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
 st2workflowengine:
@@ -361,6 +392,11 @@ st2workflowengine:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2scheduler
 # TODO: Description TBD
 st2scheduler:
@@ -380,6 +416,11 @@ st2scheduler:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2notifier
 # st2notifier runs in active-active mode and requires for that coordination backend like Redis or Zookeeper
 st2notifier:
@@ -399,6 +440,11 @@ st2notifier:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 # https://docs.stackstorm.com/reference/ha.html#st2actionrunner
 # Multiple st2actionrunner processes can run in active-active with only connections to MongoDB and RabbitMQ. Work gets naturally
 # distributed across runners via RabbitMQ. Adding more st2actionrunner processes increases the ability of StackStorm to execute actions.
@@ -428,6 +474,21 @@ st2actionrunner:
   #   ip: 8.8.8.8
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
+
+# https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
+# Please see st2.packs.sensors for each sensor instance's config.
+# This contains settings that are common to all sensor pods.
+st2sensorcontainer:
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 
 # The st2client deployment/pod simplifies ad-hoc administration.
 # st2client is a special purpose actionrunner pod, but you can customize it separately
@@ -437,6 +498,11 @@ st2client:
   image: {}
     ## Note that Helm templating is supported in this block!
     #tag: "{{ .Values.image.tag }}"
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.
@@ -459,6 +525,11 @@ st2garbagecollector:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 
 ##
 ## StackStorm ChatOps (https://docs.stackstorm.com/chatops/index.html)
@@ -502,6 +573,11 @@ st2chatops:
   affinity: {}
   serviceAccount:
     attach: false
+  # postStartScript is optional. It has the contents of a bash script.
+  # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  postStartScript: ""
 
 ##
 ## Various batch jobs (apply-rbac-definitions, apikey-load, key-load, register-content)


### PR DESCRIPTION
This builds on the postStart lifecycle hook from #219, but allows adding custom `postStartScript` (via values) to each deployment pod.

In my old 1ppc-based st2 cluster, the entrypoint script had some cluster-specific
customizations. With the current docker images, we don't use an entrypoint script.
Some of those customizations do not translate well to cacheable Dockerfile commands.

The `postStart` lifecycle event provides something similar in that I can add those
cluster-specific customizations when I can't bake the changes directly into custom
docker images.

For example, in the actionrunner pods, I have a script that:
  - configures ansible,
  - clones a git repo with ansible-related content,
  - configures ssmtp in the pod for sending email,
  - and runs a sanity check on some perl modules used by an internal pack
    (the perl modules themselves are baked into the docker image).
And in the chatops pod, our image has a slightly customized version of hubot that
needs an additional config file. That config file should not be baked into the image.

We also use the init script for rapid testing of changes in our development st2 cluster
before we bake them into the docker images (where baking the changes in makes sense).

Though these could potentially be done via initContainers, adding custom initContainers
becomes much more complex when you consider the required additional volumes and volumeMounts.

see:
https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/