### PR TITLE
Add optional (advanced-only) hubot-scripts volume to st2chatops pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * st2chatops change: If `st2chatops.env.ST2_API_KEY` is defined, do not set `ST2_AUTH_USERNAME` or `ST2_AUTH_PASSWORD` env vars any more. (#197) (by @cognifloyd)
 * Add image.tag overrides for all deployments. (#200) (by @cognifloyd)
 * If your k8s cluster admin requires custom annotations (eg: to indicate mongo or rabbitmq usage), you can now add those to each set of pods. (#195) (by @cognifloyd)
+* Add optional hubot-scripts volume to st2chatops pod. To add this, define `st2chatops.hubotScriptsVolume`. (#207) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1448,6 +1448,14 @@ spec:
     {{- if .Values.st2chatops.serviceAccount.attach }}
         serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
+    {{- if .Values.st2chatops.hubotScriptsVolume }}
+        volumeMounts:
+        - name: st2-chatops-hubot-scripts-vol
+          mountPath: /opt/stackstorm/chatops/scripts
+      volumes:
+        - name: st2-chatops-hubot-scripts-vol
+          {{- toYaml .Values.st2chatops.hubotScriptsVolume | nindent 10 }}
+    {{- end }}
     {{- with .Values.st2chatops.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -513,7 +513,7 @@ st2chatops:
   # Advanced use-cases only. If defined, this hubot-scripts volume gets mounted to: /opt/stackstorm/chatops/scripts
   # This volume (using any k8s storage solution, including configmap) allows for hubot customization.
   # Most installations should not use this.
-  # Please refer to the hubot documentaiton for details on writing .js or .coffeescript hubot extensions.
+  # For details on writing .js or .coffeescript hubot extensions, see: https://hubot.github.com/docs/scripting/
   hubotScriptsVolume: {}
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}

--- a/values.yaml
+++ b/values.yaml
@@ -510,6 +510,11 @@ st2chatops:
       memory: "50Mi"
       cpu: "5m"
   annotations: {}
+  # Advanced use-cases only. If defined, this hubot-scripts volume gets mounted to: /opt/stackstorm/chatops/scripts
+  # This volume (using any k8s storage solution, including configmap) allows for hubot customization.
+  # Most installations should not use this.
+  # Please refer to the hubot documentaiton for details on writing .js or .coffeescript hubot extensions.
+  hubotScriptsVolume: {}
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
This is for advanced use-cases only, and should generally not be used.
However, adding volumes is not possible from parent helm charts, so this is a limited, but useful, extension point.

I need to support an in-house acl solution for hubot. We use a hubot script to provide that feature. Given the current chart, there is no clean way to inject these scripts before chatops is started. This PR adds a simple, targeted way to enable this feature while keeping its footprint small.

NB. In my case, I have a custom docker image that includes the dependencies for my script, but there is also a config file that needs to be deployed via a volume of some kind, so embedding that in the docker image as well isn't feasible.