### PR TITLE
Add preRegisterContentCommand in an initContainer for register-content job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@
 * Fix permissions for /home/stanley/.ssh/stanley_rsa using the postStart lifecycle hook (#219) (by @cognifloyd)
 * Make system_user configurable when using custom st2actionrunner images that do not provide stanley (#220) (by @cognifloyd)
 * Allow providing scripts in values for use in lifecycle postStart hooks of all deployments. (#206) (by @cognifloyd)
-* Add preRegisterContentCommand in an initContainer for register-content job (#213) (by @cognifloyd)
+* Add preRegisterContentCommand in an initContainer for register-content job to run last-minute content customizations (#213) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * Fix permissions for /home/stanley/.ssh/stanley_rsa using the postStart lifecycle hook (#219) (by @cognifloyd)
 * Make system_user configurable when using custom st2actionrunner images that do not provide stanley (#220) (by @cognifloyd)
 * Allow providing scripts in values for use in lifecycle postStart hooks of all deployments. (#206) (by @cognifloyd)
+* Add preRegisterContentCommand in an initContainer for register-content job (#213) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -377,6 +377,22 @@ spec:
       {{- if $.Values.st2.packs.images -}}
         {{- include "packs-initContainers" . | nindent 6 }}
       {{ end }}
+      {{- if $.Values.jobs.preRegisterContentCommand }}
+      - name: st2-register-content-custom-init
+        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command: {{- toYaml $.Values.jobs.preRegisterContentCommand | nindent 8 }}
+        volumeMounts:
+        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        - name: st2-pack-configs-vol
+          mountPath: /opt/stackstorm/configs/
+        {{- if .Values.st2.packs.images }}
+        - name: st2-packs-vol
+          mountPath: /opt/stackstorm/packs/
+        - name: st2-virtualenvs-vol
+          mountPath: /opt/stackstorm/virtualenvs/
+        {{- end }}
+      {{ end }}
       containers:
       - name: st2-register-content
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'

--- a/values.yaml
+++ b/values.yaml
@@ -585,9 +585,21 @@ st2chatops:
 jobs:
   annotations: {}
   # Override default image settings (for now, only tag can be overridden)
+  # The Jobs use the st2actionrunner image
   image: {}
     ## Note that Helm templating is supported in this block!
     #tag: "{{ .Values.image.tag }}"
+  # If defined, this preRegisterContentCommand runs in an initContainer on the st2-register-content Job.
+  # The initContainer also uses the st2actionrunner image but runs this command instead of its entrypoint.
+  preRegisterContentCommand: []
+    # For example, to disable aliases in the "packs" system pack before content is registered:
+    # - "/bin/bash"
+    # - "-c"
+    # - |
+    #   sed -i -e 's/^\(\s*\)enabled: true/\1enabled: false/' /opt/stackstorm/packs/packs/aliases/*.yaml
+    #   for alias in /opt/stackstorm/packs/packs/aliases/*.yaml; do
+    #     grep -q 'enabled:' ${alias} || sed -i -e 's/^\(\s*\)name:\(.*\)$/\1name: \2\n\1enabled: false/m' ${alias}
+    #   done
   # Additional advanced settings to control pod/deployment placement
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Allow a custom command to run just before `st2-register-content` that can disable aliases/sensors in system packs.

For example
```yaml
jobs:
  preRegisterContentCommand:
    - '/bin/bash'
    - '-c'
    - |
      sed -i -e 's/^\(\s*\)enabled: true/\1enabled: false/' /opt/stackstorm/packs/packs/aliases/*.yaml
      sed -i -e 's/^\(\s*\)enabled: true/\1enabled: false/' /opt/stackstorm/packs/linux/aliases/*.yaml
```

Closes: #211