### PR TITLE
Fix tag in helper (follow up to #200)

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -137,7 +137,7 @@ Create the name of the stackstorm-ha service account to use
     {{- end }}
 # System packs
 - name: st2-system-packs
-  image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+  image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   volumeMounts:
   - name: st2-packs-vol


### PR DESCRIPTION
I missed one tag in a helper template that needed the tag fix from #200.
This fixes that.

As a release hasn't been made yet, let the Changelog entry for #200 stand as is.

Follow up for #200
