### PR TITLE
Fix stanley_rsa permissions via postStart pod lifecycle hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * Add advanced pod placment (nodeSelector, affinity, tolerations) to specs for batch Jobs pods. (#193) (by @cognifloyd)
 * Allow adding dnsPolicy and/or dnsConfig to all pods. (#201) (by @cognifloyd)
 * Move st2-config-vol volume definition and list of st2-config-vol volumeMounts to helpers to reduce duplication (#198) (by @cognifloyd)
+* Fix permissions for /home/stanley/.ssh/stanley_rsa using the postStart lifecycle hook (#219) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/configmaps_post-start-script.yaml
+++ b/templates/configmaps_post-start-script.yaml
@@ -18,4 +18,8 @@ data:
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   post-start.sh: |
     #!/bin/bash
+    mkdir -p /home/stanley/.ssh
+    cp -L /home/stanley/.ssh{-key-vol,}/stanley_rsa
     chown -R stanley:stanley /home/stanley/.ssh/
+    chmod 400 /home/stanley/.ssh/stanley_rsa
+    chmod 500 /home/stanley/.ssh

--- a/templates/configmaps_post-start-script.yaml
+++ b/templates/configmaps_post-start-script.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $.Release.Name }}-st2actionrunner-post-start-script
+  annotations:
+    description: Custom postStart lifecycle event handler script for st2actionrunner
+  labels:
+    app: st2
+    tier: backend
+    vendor: stackstorm
+    chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
+    release: {{ $.Release.Name }}
+    heritage: {{ $.Release.Service }}
+data:
+  # k8s calls this script in parallel with starting st2actionrunner (ie the same time as ENTRYPOINT)
+  # The pod will not be marked as "running" until this script completes successfully.
+  # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
+  post-start.sh: |
+    #!/bin/bash
+    chown -R stanley:stanley /home/stanley/.ssh/

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1035,6 +1035,13 @@ spec:
           mountPath: /opt/stackstorm/virtualenvs
           readOnly: true
         {{- end }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "-c", "/post-start.sh"]
         resources:
           {{- toYaml .Values.st2actionrunner.resources | nindent 10 }}
     {{- if .Values.st2actionrunner.serviceAccount.attach }}
@@ -1061,6 +1068,9 @@ spec:
         {{- if .Values.st2.packs.images }}
 {{- include "packs-volumes" . | indent 8 }}
         {{- end }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2actionrunner-post-start-script
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}
     {{- end }}
@@ -1274,10 +1284,17 @@ spec:
           mountPath: /opt/stackstorm/virtualenvs
           readOnly: true
         {{- end }}
+        - name: st2-post-start-script-vol
+          mountPath: /post-start.sh
+          subPath: post-start.sh
         command:
           - 'bash'
           - '-ec'
           - 'while true; do sleep 999; done'
+        lifecycle:
+          postStart:
+            exec:
+              command: ["/bin/bash", "-c", "/post-start.sh"]
         resources:
           requests:
             memory: "5Mi"
@@ -1320,6 +1337,9 @@ spec:
         {{- if .Values.st2.packs.images }}
 {{- include "packs-volumes" . | indent 8 }}
         {{- end }}
+        - name: st2-post-start-script-vol
+          configMap:
+            name: {{ .Release.Name }}-st2actionrunner-post-start-script
 
 {{ if .Values.st2chatops.enabled -}}
 ---

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1020,8 +1020,7 @@ spec:
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
-          mountPath: /home/stanley/.ssh/
-          #readOnly: true
+          mountPath: /home/stanley/.ssh-key-vol/
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1064,9 +1063,7 @@ spec:
             - key: private_key
               path: stanley_rsa
               # 0400 file permission
-              #mode: 256
-              # 0600 file permission
-              mode: 384
+              mode: 256
         {{- if .Values.st2.packs.images }}
 {{- include "packs-volumes" . | indent 8 }}
         {{- end }}
@@ -1271,8 +1268,7 @@ spec:
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
-          mountPath: /home/stanley/.ssh/
-          #readOnly: true
+          mountPath: /home/stanley/.ssh-key-vol/
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1335,9 +1331,7 @@ spec:
             - key: private_key
               path: stanley_rsa
               # 0400 file permission
-              #mode: 256
-              # 0600 file permission
-              mode: 384
+              mode: 256
         {{- if .Values.st2.packs.images }}
 {{- include "packs-volumes" . | indent 8 }}
         {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1021,7 +1021,7 @@ spec:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
-          readOnly: true
+          #readOnly: true
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1064,7 +1064,9 @@ spec:
             - key: private_key
               path: stanley_rsa
               # 0400 file permission
-              mode: 256
+              #mode: 256
+              # 0600 file permission
+              mode: 384
         {{- if .Values.st2.packs.images }}
 {{- include "packs-volumes" . | indent 8 }}
         {{- end }}
@@ -1270,7 +1272,7 @@ spec:
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
           mountPath: /home/stanley/.ssh/
-          readOnly: true
+          #readOnly: true
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1333,7 +1335,9 @@ spec:
             - key: private_key
               path: stanley_rsa
               # 0400 file permission
-              mode: 256
+              #mode: 256
+              # 0600 file permission
+              mode: 384
         {{- if .Values.st2.packs.images }}
 {{- include "packs-volumes" . | indent 8 }}
         {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1041,7 +1041,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["/bin/bash", "-c", "/post-start.sh"]
+              command: ["/bin/bash", "/post-start.sh"]
         resources:
           {{- toYaml .Values.st2actionrunner.resources | nindent 10 }}
     {{- if .Values.st2actionrunner.serviceAccount.attach }}
@@ -1294,7 +1294,7 @@ spec:
         lifecycle:
           postStart:
             exec:
-              command: ["/bin/bash", "-c", "/post-start.sh"]
+              command: ["/bin/bash", "/post-start.sh"]
         resources:
           requests:
             memory: "5Mi"

--- a/tests/st2tests.sh
+++ b/tests/st2tests.sh
@@ -30,6 +30,15 @@ load "${BATS_HELPERS_DIR}/bats-file/load.bash"
   assert_line --partial 'St2-Api-Key'
 }
 
+@test 'stanley_rsa file has correct permissions and ownership' {
+  local private_key="/home/stanley/.ssh/stanley_rsa"
+  assert_file_exist "${private_key}"
+  assert_file_not_empty "${private_key}"
+  assert_file_permission "500" "${private_key}"
+  assert_file_permission "400" "${private_key}"
+  assert_file_owner "stanley" "${private_key}"
+}
+
 @test 'st2 user can log in with auth credentials' {
   run st2 login ${ST2_AUTH_USERNAME} --password ${ST2_AUTH_PASSWORD} -w
   assert_success

--- a/tests/st2tests.sh
+++ b/tests/st2tests.sh
@@ -30,15 +30,6 @@ load "${BATS_HELPERS_DIR}/bats-file/load.bash"
   assert_line --partial 'St2-Api-Key'
 }
 
-@test 'stanley_rsa file has correct permissions and ownership' {
-  local private_key="/home/stanley/.ssh/stanley_rsa"
-  assert_file_exist "${private_key}"
-  assert_file_not_empty "${private_key}"
-  assert_file_permission "500" "${private_key}"
-  assert_file_permission "400" "${private_key}"
-  assert_file_owner "stanley" "${private_key}"
-}
-
 @test 'st2 user can log in with auth credentials' {
   run st2 login ${ST2_AUTH_USERNAME} --password ${ST2_AUTH_PASSWORD} -w
   assert_success
@@ -58,6 +49,18 @@ load "${BATS_HELPERS_DIR}/bats-file/load.bash"
   assert_line --partial 'return_code: 0'
   assert_line --partial "stderr: ''"
   assert_line --partial 'stdout: uid=1000(stanley) gid=1000(stanley) groups=1000(stanley)'
+  assert_line --partial 'succeeded: true'
+}
+
+@test 'stanley_rsa file has correct permissions and ownership' {
+  local ssh_dir="/home/stanley/.ssh"
+  local private_key="${ssh_dir}/stanley_rsa"
+  run st2 run core.local cmd="find ${ssh_dir} -printf '%p: %u %g %m\n'"
+  assert_success
+  assert_line --partial 'return_code: 0'
+  assert_line --partial "stderr: ''"
+  assert_line --partial "${ssh_dir}: stanley stanley 500"
+  assert_line --partial "${private_key}: stanley stanley 400"
   assert_line --partial 'succeeded: true'
 }
 


### PR DESCRIPTION
I extracted this change from #206.

Use the postStart lifecycle event in st2actionrunner and st2client pods to correct file permissions on the stanley ssh private key.
Includes a test to ensure the key permissions are correct.

see:
https://kubernetes.io/docs/tasks/configure-pod-container/attach-handler-lifecycle-event/
https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/

- Fix stanley_rsa file permissions with postStart lifecycle hook script for st2actionrunner and st2client
- bash needs to run the script directly not with -c
- make the ssh key writable so we can change permissions at runtime
- mount ssh-key to separate directory, cp, and fix permissions
- add test for stanley_rsa file ownership
- use st2 as test intermediary
- add changelog entry

Fixes #84
