### PR TITLE
Make system_user "stanley" configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Allow adding dnsPolicy and/or dnsConfig to all pods. (#201) (by @cognifloyd)
 * Move st2-config-vol volume definition and list of st2-config-vol volumeMounts to helpers to reduce duplication (#198) (by @cognifloyd)
 * Fix permissions for /home/stanley/.ssh/stanley_rsa using the postStart lifecycle hook (#219) (by @cognifloyd)
+* Make system_user configurable when using custom st2actionrunner images that do not provide stanley (#220) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/configmaps_post-start-script.yaml
+++ b/templates/configmaps_post-start-script.yaml
@@ -18,8 +18,12 @@ data:
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   post-start.sh: |
     #!/bin/bash
-    mkdir -p /home/stanley/.ssh
-    cp -L /home/stanley/.ssh{-key-vol,}/stanley_rsa
-    chown -R stanley:stanley /home/stanley/.ssh/
-    chmod 400 /home/stanley/.ssh/stanley_rsa
-    chmod 500 /home/stanley/.ssh
+      {{- $system_user := $.Values.st2.system_user.user }}
+      {{- $ssh_key_file := tpl $.Values.st2.system_user.ssh_key_file $ }}
+      {{- $ssh_key_file_name := base $ssh_key_file }}
+      {{- $ssh_key_file_dir := dir $ssh_key_file }}
+    mkdir -p {{ $ssh_key_file_dir }}
+    cp -L {{ dir $ssh_key_file_dir }}/.ssh-key-vol/{{ $ssh_key_file_name }} {{ $ssh_key_file }}
+    chown -R {{ $system_user }}:{{ $system_user }} {{ $ssh_key_file_dir }}
+    chmod 400 {{ $ssh_key_file }}
+    chmod 500 {{ $ssh_key_file_dir }}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -19,6 +19,9 @@ data:
   st2.docker.conf: |
     [auth]
     api_url = http://{{ .Release.Name }}-st2api:9101/
+    [system_user]
+    user = {{ .Values.st2.system_user.user }}
+    ssh_key_file = {{ tpl .Values.st2.system_user.ssh_key_file . }}
     {{- if index .Values "redis" "enabled" }}
     [coordination]
     url = redis://{{ template "redis-nodes" $ }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1020,7 +1020,7 @@ spec:
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
-          mountPath: /home/stanley/.ssh-key-vol/
+          mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1061,7 +1061,7 @@ spec:
             secretName: {{ .Release.Name }}-st2-ssh
             items:
             - key: private_key
-              path: stanley_rsa
+              path: {{ tpl .Values.st2.system_user.ssh_key_file . | base }}
               # 0400 file permission
               mode: 256
         {{- if .Values.st2.packs.images }}
@@ -1268,7 +1268,7 @@ spec:
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
-          mountPath: /home/stanley/.ssh-key-vol/
+          mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
         {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1329,7 +1329,7 @@ spec:
             secretName: {{ .Release.Name }}-st2-ssh
             items:
             - key: private_key
-              path: stanley_rsa
+              path: {{ tpl .Values.st2.system_user.ssh_key_file . | base }}
               # 0400 file permission
               mode: 256
         {{- if .Values.st2.packs.images }}

--- a/values.yaml
+++ b/values.yaml
@@ -64,6 +64,13 @@ st2:
     [api]
     allow_origin = '*'
 
+  # This mirrors the [system_user] section of st2.conf, but makes the values available for helm templating.
+  # If you change the user, you must provide a customized st2actionrunner image that includes your user.
+  system_user:
+    user: stanley
+    # templating is allowed for this key
+    ssh_key_file: "/home/{{ .Values.st2.system_user.user }}/.ssh/stanley_rsa"
+
   # Custom pack configs and image settings.
   #
   # By default, system packs are available. However, since 'st2 pack install' cannot be run in the k8s cluster,


### PR DESCRIPTION
Currently the system_user is hard-coded to be "stanley". However, people can use a custom st2actionrunner image that does not have "stanley", and instead has some other user that StackStorm should use.

This PR allows us to inform helm about the alternate user, removing the hard-coded references to the "stanley" user.

- make system_user/stanley configurable
- changelog entry

Closes #208