### PR TITLE
Make st2.packs.sensors pull default values from st2sensorcontainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
 * Make system_user configurable when using custom st2actionrunner images that do not provide stanley (#220) (by @cognifloyd)
 * Allow providing scripts in values for use in lifecycle postStart hooks of all deployments. (#206) (by @cognifloyd)
 * Add preRegisterContentCommand in an initContainer for register-content job to run last-minute content customizations (#213) (by @cognifloyd)
+* Minimize required sensor config by using default values from st2sensorcontainer for each sensor in st2.packs.sensors (#221) (by @cognifloyd)
 
 ## v0.60.0
 * Switch st2 version to `v3.5dev` as a new latest development version (#187)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -982,13 +982,15 @@ spec:
     {{- end }}
 
 {{- range .Values.st2.packs.sensors }}
+  {{- $sensor := deepCopy $.Values.st2sensorcontainer | mustMergeOverwrite . }}
+  {{- $name := print "st2sensorcontainer" (include "hyphenPrefix" $sensor.name) }}
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ $.Release.Name }}-st2sensorcontainer{{ template "hyphenPrefix" .name }}
+  name: {{ $.Release.Name }}-{{ $name }}
   labels:
-    app: st2sensorcontainer{{ template "hyphenPrefix" .name }}
+    app: {{ $name }}
     tier: backend
     vendor: stackstorm
     chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
@@ -997,7 +999,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: st2sensorcontainer{{ template "hyphenPrefix" .name }}
+      app: {{ $name }}
       release: {{ $.Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
   # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance. Each sensor node needs to be
@@ -1007,7 +1009,7 @@ spec:
   template:
     metadata:
       labels:
-        app: st2sensorcontainer{{ template "hyphenPrefix" .name }}
+        app: {{ $name }}
         tier: backend
         vendor: stackstorm
         chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
@@ -1020,8 +1022,8 @@ spec:
         {{- if $.Values.st2sensorcontainer.postStartScript }}
         checksum/post-start-script: {{ $.Values.st2sensorcontainer.postStartScript | sha256sum }}
         {{- end }}
-        {{- if .annotations }}
-          {{- toYaml .annotations | nindent 8 }}
+        {{- if $sensor.annotations }}
+          {{- toYaml $sensor.annotations | nindent 8 }}
         {{- end }}
     spec:
       imagePullSecrets:
@@ -1038,26 +1040,26 @@ spec:
         {{- include "packs-initContainers" $ | nindent 6 }}
       {{- end }}
       containers:
-      - name: st2sensorcontainer{{ template "hyphenPrefix" .name }}
-        image: '{{ template "imageRepository" $ }}/st2sensorcontainer:{{ tpl (.image.tag | default $.Values.image.tag) $ }}'
+      - name: {{ $name }}
+        image: '{{ template "imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
-        {{- with .readinessProbe }}
+        {{- with $sensor.readinessProbe }}
         # Probe to check if app is running. Failure will lead to a pod restart.
         readinessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- with .livenessProbe }}
+        {{- with $sensor.livenessProbe }}
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if .ref }}
+        {{- if $sensor.ref }}
         command:
           - /opt/stackstorm/st2/bin/st2sensorcontainer
           - --config-file=/etc/st2/st2.conf
           - --config-file=/etc/st2/st2.docker.conf
           - --config-file=/etc/st2/st2.user.conf
           - --single-sensor-mode
-          - --sensor-ref={{ .ref }}
+          - --sensor-ref={{ $sensor.ref }}
         {{- end }}
         envFrom:
         - configMapRef:
@@ -1087,8 +1089,8 @@ spec:
               command: ["/bin/bash", "/post-start.sh"]
         {{- end }}
         resources:
-          {{- toYaml .resources | nindent 10 }}
-    {{- if .serviceAccount.attach }}
+          {{- toYaml $sensor.resources | nindent 10 }}
+    {{- if $sensor.serviceAccount.attach }}
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" $ }}
     {{- end }}
       volumes:
@@ -1115,13 +1117,13 @@ spec:
     {{- with $.Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .nodeSelector }}
+    {{- with $sensor.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .affinity }}
+    {{- with $sensor.affinity }}
       affinity: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .tolerations }}
+    {{- with $sensor.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
 {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -982,7 +982,10 @@ spec:
     {{- end }}
 
 {{- range .Values.st2.packs.sensors }}
-  {{- $sensor := deepCopy $.Values.st2sensorcontainer | mustMergeOverwrite . }}
+  {{- $sensor := omit $.Values.st2sensorcontainer "name" "ref" "postStartScript" }}
+  {{- range $key, $val := . }}
+    {{- $_ := set $sensor $key $val }}
+  {{- end }}
   {{- $name := print "st2sensorcontainer" (include "hyphenPrefix" $sensor.name) }}
 ---
 apiVersion: apps/v1

--- a/values.yaml
+++ b/values.yaml
@@ -100,7 +100,7 @@ st2:
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.
     # Each sensor node needs to be provided with proper partition information to share work with other sensor
     # nodes so that the same sensor does not run on different nodes.
-    # Defaults values cwome from st2sensorcontainer (see below), with per-sensor overrides defined here.
+    # Defaults come from st2sensorcontainer (see below), with per-sensor overrides defined here.
     sensors:
       # Specify default container that executes all sensors.
       # To partition sensors with one sensor per node, override st2.packs.sensors.

--- a/values.yaml
+++ b/values.yaml
@@ -100,6 +100,7 @@ st2:
     # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.
     # Each sensor node needs to be provided with proper partition information to share work with other sensor
     # nodes so that the same sensor does not run on different nodes.
+    # Defaults values cwome from st2sensorcontainer (see below), with per-sensor overrides defined here.
     sensors:
       # Specify default container that executes all sensors.
       # To partition sensors with one sensor per node, override st2.packs.sensors.
@@ -482,8 +483,25 @@ st2actionrunner:
 
 # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
 # Please see st2.packs.sensors for each sensor instance's config.
-# This contains settings that are common to all sensor pods.
+# This contains default settings for all sensor pods.
 st2sensorcontainer:
+  resources:
+    requests:
+      memory: "100Mi"
+      cpu: "50m"
+  # Override default image settings (for now, only tag can be overridden)
+  image: {}
+    ## Note that Helm templating is supported in this block!
+    #tag: "{{ .Values.image.tag }}"
+  livenessProbe: {}
+  readinessProbe: {}
+  annotations: {}
+  # Additional advanced settings to control pod/deployment placement
+  affinity: {}
+  nodeSelector: {}
+  tolerations: []
+  serviceAccount:
+    attach: false
   # postStartScript is optional. It has the contents of a bash script.
   # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
   # The pod will not be marked as "running" until this script completes successfully.


### PR DESCRIPTION
This simplifies the one-sensor-per-pod method by pulling default values from `st2sensorcontainer`.

In other words, this makes `st2sensorcontainer` provide defaults for each pod in `st2.packs.sensors`.