### PR TITLE
Clarify the distinction between sensor modes: all-sensors-in-one-pod and one-sensor-per-pod

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## In Development
-* Explicitly differentiate sensor modes: `all-sensors-in-one-pod` vs `one-sensor-per-pod`. Exposes the mode in new `st2sensor/mode` annotation. (#222) (by @cognifloyd)
+* Explicitly differentiate sensor modes: `all-sensors-in-one-pod` vs `one-sensor-per-pod`. Exposes the mode in new `stackstorm/sensor-mode` annotation. (#222) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
 ## In Development
-* Make the distinction between sensor modes: all-sensors-in-one-pod and one-sensor-per-pod (#222) (by @cognifloyd)
+* Explicitly differentiate sensor modes: `all-sensors-in-one-pod` vs `one-sensor-per-pod`. Exposes the mode in new `st2sensor/mode` annotation.
+  **NOTE:** For `all-sensors-in-one-pod` mode (the default) existing installations should move any customized sensor values from `st2.packs.sensors` to `st2sensorcontainer`.
+  For `one-sensor-per-pod` mode all entries in `st2.packs.sensors` now require a sensor `ref`. (#222) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Make the distinction between sensor modes: all-sensors-in-one-pod and one-sensor-per-pod (#222) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,7 @@
 # Changelog
 
 ## In Development
-* Explicitly differentiate sensor modes: `all-sensors-in-one-pod` vs `one-sensor-per-pod`. Exposes the mode in new `st2sensor/mode` annotation.
-  **NOTE:** For `all-sensors-in-one-pod` mode (the default) existing installations should move any customized sensor values from `st2.packs.sensors` to `st2sensorcontainer`.
-  For `one-sensor-per-pod` mode all entries in `st2.packs.sensors` now require a sensor `ref`. (#222) (by @cognifloyd)
+* Explicitly differentiate sensor modes: `all-sensors-in-one-pod` vs `one-sensor-per-pod`. Exposes the mode in new `st2sensor/mode` annotation. (#222) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1038,9 +1038,9 @@ spec:
         checksum/post-start-script: {{ $.Values.st2sensorcontainer.postStartScript | sha256sum }}
         {{- end }}
         {{- if $one_sensor_per_pod }}
-        st2sensor/mode: one-sensor-per-pod
+        stackstorm/sensor-mode: one-sensor-per-pod
         {{- else }}
-        st2sensor/mode: all-sensors-in-one-pod
+        stackstorm/sensor-mode: all-sensors-in-one-pod
         {{- end }}
         {{- if $sensor.annotations }}
           {{- toYaml $sensor.annotations | nindent 8 }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -989,13 +989,11 @@ spec:
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
 
-{{- $one_sensor_per_pod := not ($.Values.st2.packs.sensors | empty) }}
-{{- range ($one_sensor_per_pod | ternary ($.Values.st2.packs.sensors) (until 1)) }}
+{{- $one_sensor_per_pod := or (gt (len $.Values.st2.packs.sensors) 1) (index $.Values.st2.packs.sensors 0 "ref") }}
+{{- range .Values.st2.packs.sensors }}
   {{- $sensor := omit $.Values.st2sensorcontainer "name" "ref" "postStartScript" }}
-  {{- if $one_sensor_per_pod }}
-    {{- range $key, $val := . }}
-      {{- $_ := set $sensor $key $val }}
-    {{- end }}
+  {{- range $key, $val := . }}
+    {{- $_ := set $sensor $key $val }}
   {{- end }}
   {{- $name := print "st2sensorcontainer" (include "hyphenPrefix" $sensor.name) }}
 ---
@@ -1081,7 +1079,7 @@ spec:
           - --config-file=/etc/st2/st2.docker.conf
           - --config-file=/etc/st2/st2.user.conf
           - --single-sensor-mode
-          - --sensor-ref={{ required "You must define `ref` for everything in st2.packs.sensors. This assigns each sensor to a pod." $sensor.ref }}
+          - --sensor-ref={{ $sensor.ref }}
         {{- end }}
         envFrom:
         - configMapRef:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -989,10 +989,10 @@ spec:
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
 
-{{- $use_packs_sensors := not ($.Values.st2.packs.sensors | empty) }}
-{{- range ($use_packs_sensors | ternary ($.Values.st2.packs.sensors) (until 1)) }}
+{{- $one_sensor_per_pod := not ($.Values.st2.packs.sensors | empty) }}
+{{- range ($one_sensor_per_pod | ternary ($.Values.st2.packs.sensors) (until 1)) }}
   {{- $sensor := omit $.Values.st2sensorcontainer "name" "ref" "postStartScript" }}
-  {{- if $use_packs_sensors }}
+  {{- if $one_sensor_per_pod }}
     {{- range $key, $val := . }}
       {{- $_ := set $sensor $key $val }}
     {{- end }}
@@ -1039,7 +1039,7 @@ spec:
         {{- if $.Values.st2sensorcontainer.postStartScript }}
         checksum/post-start-script: {{ $.Values.st2sensorcontainer.postStartScript | sha256sum }}
         {{- end }}
-        {{- if $use_packs_sensors }}
+        {{- if $one_sensor_per_pod }}
         st2sensor/mode: one-sensor-per-pod
         {{- else }}
         st2sensor/mode: all-sensors-in-one-pod
@@ -1074,7 +1074,7 @@ spec:
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if $use_packs_sensors }}
+        {{- if $one_sensor_per_pod }}
         command:
           - /opt/stackstorm/st2/bin/st2sensorcontainer
           - --config-file=/etc/st2/st2.conf

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -989,10 +989,13 @@ spec:
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
 
-{{- range .Values.st2.packs.sensors }}
+{{- $use_packs_sensors := not ($.Values.st2.packs.sensors | empty) }}
+{{- range ($use_packs_sensors | ternary ($.Values.st2.packs.sensors) (until 1)) }}
   {{- $sensor := omit $.Values.st2sensorcontainer "name" "ref" "postStartScript" }}
-  {{- range $key, $val := . }}
-    {{- $_ := set $sensor $key $val }}
+  {{- if $use_packs_sensors }}
+    {{- range $key, $val := . }}
+      {{- $_ := set $sensor $key $val }}
+    {{- end }}
   {{- end }}
   {{- $name := print "st2sensorcontainer" (include "hyphenPrefix" $sensor.name) }}
 ---
@@ -1013,9 +1016,12 @@ spec:
       app: {{ $name }}
       release: {{ $.Release.Name }}
   # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
-  # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance. Each sensor node needs to be
-  # provided with proper partition information to share work with other sensor nodes so that the same sensor does not run on different nodes.
-  # See Partitioning Sensors for information on how to partition sensors.
+  # It is possible to run st2sensorcontainer(s) in one of these modes:
+  #   (1) run all sensors in one pod (1 deployment with 1 pod, the default); or
+  #   (2) run one sensor per pod using st2.packs.sensors.
+  # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.
+  # Each sensor node needs to be provided with proper partition information to share work with other sensor nodes
+  # so that the same sensor does not run on different nodes. See: https://docs.stackstorm.com/reference/sensor_partitioning.html
   replicas: 1
   template:
     metadata:
@@ -1032,6 +1038,11 @@ spec:
         checksum/datastore-key: {{ include (print $.Template.BasePath "/secrets_datastore_crypto_key.yaml") $ | sha256sum }}
         {{- if $.Values.st2sensorcontainer.postStartScript }}
         checksum/post-start-script: {{ $.Values.st2sensorcontainer.postStartScript | sha256sum }}
+        {{- end }}
+        {{- if $use_packs_sensors }}
+        st2sensor/mode: one-sensor-per-pod
+        {{- else }}
+        st2sensor/mode: all-sensors-in-one-pod
         {{- end }}
         {{- if $sensor.annotations }}
           {{- toYaml $sensor.annotations | nindent 8 }}
@@ -1063,14 +1074,14 @@ spec:
         livenessProbe:
           {{- toYaml . | nindent 10 }}
         {{- end }}
-        {{- if $sensor.ref }}
+        {{- if $use_packs_sensors }}
         command:
           - /opt/stackstorm/st2/bin/st2sensorcontainer
           - --config-file=/etc/st2/st2.conf
           - --config-file=/etc/st2/st2.docker.conf
           - --config-file=/etc/st2/st2.user.conf
           - --single-sensor-mode
-          - --sensor-ref={{ $sensor.ref }}
+          - --sensor-ref={{ required "You must define `ref` for everything in st2.packs.sensors. This assigns each sensor to a pod." $sensor.ref }}
         {{- end }}
         envFrom:
         - configMapRef:

--- a/values.yaml
+++ b/values.yaml
@@ -152,24 +152,31 @@ st2:
     #   (2) run one sensor per pod using st2.packs.sensors (here).
     # Each sensor node needs to be provided with proper partition information to share work with other sensor
     # nodes so that the same sensor does not run on different nodes.
-    # When this is empty (the default), the chart adds one pod to run all sensors.
-    sensors: []
-      # This is a list of sensor pods (one-sensor-per-pod).
-      # Each entry should have `name` (the pod name) and `ref` (which sensor to run in the pod).
-      # Each entry can also include other pod settings (annotations, image, resources, etc).
-      # These optional pod settings default to the values in st2sensorcontainer,
-      # note: postStartScript is not valid in st2.packs.sensors. Use st2sensorcontainer.postStartScript instead.
-      #
-      # This example only defines name and ref, accepting all defaults in st2sensorcontainer:
-      # - name: some-sensor-node
-      #   ref: some_pack.some_sensor
-      #
-      # This example also uses a custom image tag:
-      # - name: another-sensor-node
-      #   ref: some_pack.another_sensor
-      #   image:
-      #     tag: 3.5.0-another_sensor-r1
-
+    # Defaults come from st2sensorcontainer (see below), with per-sensor overrides defined here.
+    sensors:
+      # With only one sensor listed here, we use all-sensors-in-one-pod mode, unless that sensor has a `ref`.
+      # To partition sensors with one-sensor-per-node, override st2.packs.sensors.
+      # In one-sensor-per-pod mode, make sure each sensor here has both `name` and `ref` (which sensor to run in the pod).
+      # NOTE: Do not modify this file.
+      - name:
+        livenessProbe: {}
+        readinessProbe: {}
+        annotations: {}
+        resources:
+          requests:
+            memory: "100Mi"
+            cpu: "50m"
+        # Override default image settings (for now, only tag can be overridden)
+        image: {}
+          ## Note that Helm templating is supported in this block!
+          #tag: "{{ .Values.image.tag }}"
+        # Additional advanced settings to control pod/deployment placement
+        affinity: {}
+        nodeSelector: {}
+        tolerations: []
+        serviceAccount:
+          attach: false
+        # note: postStartScript is not valid here. Use st2sensorcontainer.postStartScript instead.
   # Import data into StackStorm's Key/Value datastore (https://docs.stackstorm.com/datastore.html)
   keyvalue:
     #- name: st2_version
@@ -528,11 +535,8 @@ st2actionrunner:
   postStartScript: ""
 
 # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
-# It is possible to run st2sensorcontainer(s) in one of these modes:
-#   (1) run all sensors in one pod (1 deployment with 1 pod, the default); or
-#   (2) run one sensor per pod using st2.packs.sensors (see above).
-# To use the default mode (all sensors in one pod), st2.packs.sensors must be empty.
-# For one-sensor-per-pod, define defaults here and add config for each sensor to st2.packs.sensors (above).
+# Please see st2.packs.sensors for each sensor instance's config.
+# This contains default settings for all sensor pods.
 st2sensorcontainer:
   resources:
     requests:

--- a/values.yaml
+++ b/values.yaml
@@ -147,33 +147,29 @@ st2:
         # see the examples under st2.packs.volumes.packs
 
     # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
-    # It is possible to run st2sensorcontainer in HA mode by running one process on each compute instance.
+    # It is possible to run st2sensorcontainer(s) in one of these modes:
+    #   (1) run all sensors in one pod (1 deployment with 1 pod, the default); or
+    #   (2) run one sensor per pod using st2.packs.sensors (here).
     # Each sensor node needs to be provided with proper partition information to share work with other sensor
     # nodes so that the same sensor does not run on different nodes.
-    # Defaults come from st2sensorcontainer (see below), with per-sensor overrides defined here.
-    sensors:
-      # Specify default container that executes all sensors.
-      # To partition sensors with one sensor per node, override st2.packs.sensors.
-      # NOTE: Do not modify this file.
-      - name:
-        livenessProbe: {}
-        readinessProbe: {}
-        annotations: {}
-        resources:
-          requests:
-            memory: "100Mi"
-            cpu: "50m"
-        # Override default image settings (for now, only tag can be overridden)
-        image: {}
-          ## Note that Helm templating is supported in this block!
-          #tag: "{{ .Values.image.tag }}"
-        # Additional advanced settings to control pod/deployment placement
-        affinity: {}
-        nodeSelector: {}
-        tolerations: []
-        serviceAccount:
-          attach: false
-        # note: postStartScript is not valid here. Use st2sensorcontainer.postStartScript instead.
+    # When this is empty (the default), the chart adds one pod to run all sensors.
+    sensors: []
+      # This is a list of sensor pods (one-sensor-per-pod).
+      # Each entry should have `name` (the pod name) and `ref` (which sensor to run in the pod).
+      # Each entry can also include other pod settings (annotations, image, resources, etc).
+      # These optional pod settings default to the values in st2sensorcontainer,
+      # note: postStartScript is not valid in st2.packs.sensors. Use st2sensorcontainer.postStartScript instead.
+      #
+      # This example only defines name and ref, accepting all defaults in st2sensorcontainer:
+      # - name: some-sensor-node
+      #   ref: some_pack.some_sensor
+      #
+      # This example also uses a custom image tag:
+      # - name: another-sensor-node
+      #   ref: some_pack.another_sensor
+      #   image:
+      #     tag: 3.5.0-another_sensor-r1
+
   # Import data into StackStorm's Key/Value datastore (https://docs.stackstorm.com/datastore.html)
   keyvalue:
     #- name: st2_version
@@ -532,8 +528,11 @@ st2actionrunner:
   postStartScript: ""
 
 # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
-# Please see st2.packs.sensors for each sensor instance's config.
-# This contains default settings for all sensor pods.
+# It is possible to run st2sensorcontainer(s) in one of these modes:
+#   (1) run all sensors in one pod (1 deployment with 1 pod, the default); or
+#   (2) run one sensor per pod using st2.packs.sensors (see above).
+# To use the default mode (all sensors in one pod), st2.packs.sensors must be empty.
+# For one-sensor-per-pod, define defaults here and add config for each sensor to st2.packs.sensors (above).
 st2sensorcontainer:
   resources:
     requests:


### PR DESCRIPTION
This PR focuses on improving the user experience configuring sensors. It makes the distinction between two sensor modes (ways of configuring the sensors) more explicit. To achieve this, it adjusts several documentation comments in values.yaml, and adds an `st2sensor/mode` annotation to the sensor pod(s).

The two sensor modes are:

1) `all-sensors-in-one-pod` (the default)
2) `one-sensor-per-pod` (override `st2.packs.sensors` to use this mode now)

The `all-sensors-in-one-pod` mode is somewhat magical right now. The single entry in `st2.packs.sensors` looks like just an example. So, we adjust the docstring to clarify what is going on.

It also adds an `st2sensor/mode` annotation to indicate which mode the sensor pod(s) is/are configured to use.

_edit: refactored to drop the breaking change_

_This builds on #221 (merged) and was extracted from #218 as a feature that is helpful whether or not #218 is accepted._