### PR TITLE
Improve one-sensor-per-pod UX: require "ref" in st2.packs.sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Explicitly differentiate sensor modes: `all-sensors-in-one-pod` vs `one-sensor-per-pod`. Exposes the mode in new `stackstorm/sensor-mode` annotation. (#222) (by @cognifloyd)
+* Make configuring `stackstorm/sensor-mode=all-sensors-in-one-pod` more obvious by using `st2.packs.sensors` only for `one-sensor-per-pod`. `all-sensors-in-one-pod` mode now only uses values from `st2sensorcontainer`. (#246) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1110,7 +1110,7 @@ spec:
           - --single-sensor-mode
           - --sensor-ref={{ required "You must define `ref` for everything in st2.packs.sensors. This assigns each sensor to a pod." $sensor.ref }}
         {{- end }}
-        {{- if .env }}
+        {{- if $sensor.env }}
         env: {{- include "stackstorm-ha.customEnv" . | nindent 8 }}
         {{- end }}
         envFrom:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -989,11 +989,13 @@ spec:
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
 
-{{- $one_sensor_per_pod := or (gt (len $.Values.st2.packs.sensors) 1) (index $.Values.st2.packs.sensors 0 "ref") }}
-{{- range .Values.st2.packs.sensors }}
+{{- $one_sensor_per_pod := not ($.Values.st2.packs.sensors | empty) }}
+{{- range ($one_sensor_per_pod | ternary ($.Values.st2.packs.sensors) (until 1)) }}
   {{- $sensor := omit $.Values.st2sensorcontainer "name" "ref" "postStartScript" }}
-  {{- range $key, $val := . }}
-    {{- $_ := set $sensor $key $val }}
+  {{- if $one_sensor_per_pod }}
+    {{- range $key, $val := . }}
+      {{- $_ := set $sensor $key $val }}
+    {{- end }}
   {{- end }}
   {{- $name := print "st2sensorcontainer" (include "hyphenPrefix" $sensor.name) }}
 ---
@@ -1079,7 +1081,7 @@ spec:
           - --config-file=/etc/st2/st2.docker.conf
           - --config-file=/etc/st2/st2.user.conf
           - --single-sensor-mode
-          - --sensor-ref={{ $sensor.ref }}
+          - --sensor-ref={{ required "You must define `ref` for everything in st2.packs.sensors. This assigns each sensor to a pod." $sensor.ref }}
         {{- end }}
         envFrom:
         - configMapRef:

--- a/values.yaml
+++ b/values.yaml
@@ -152,31 +152,24 @@ st2:
     #   (2) run one sensor per pod using st2.packs.sensors (here).
     # Each sensor node needs to be provided with proper partition information to share work with other sensor
     # nodes so that the same sensor does not run on different nodes.
-    # Defaults come from st2sensorcontainer (see below), with per-sensor overrides defined here.
-    sensors:
-      # With only one sensor listed here, we use all-sensors-in-one-pod mode, unless that sensor has a `ref`.
-      # To partition sensors with one-sensor-per-node, override st2.packs.sensors.
-      # In one-sensor-per-pod mode, make sure each sensor here has both `name` and `ref` (which sensor to run in the pod).
-      # NOTE: Do not modify this file.
-      - name:
-        livenessProbe: {}
-        readinessProbe: {}
-        annotations: {}
-        resources:
-          requests:
-            memory: "100Mi"
-            cpu: "50m"
-        # Override default image settings (for now, only tag can be overridden)
-        image: {}
-          ## Note that Helm templating is supported in this block!
-          #tag: "{{ .Values.image.tag }}"
-        # Additional advanced settings to control pod/deployment placement
-        affinity: {}
-        nodeSelector: {}
-        tolerations: []
-        serviceAccount:
-          attach: false
-        # note: postStartScript is not valid here. Use st2sensorcontainer.postStartScript instead.
+    # When this is empty (the default), the chart adds one pod to run all sensors.
+    sensors: []
+      # This is a list of sensor pods (stackstorm/sensor-mode=one-sensor-per-pod).
+      # Each entry should have `name` (the pod name) and `ref` (which sensor to run in the pod).
+      # Each entry can also include other pod settings (annotations, image, resources, etc).
+      # These optional pod settings default to the values in st2sensorcontainer,
+      # note: postStartScript is not valid in st2.packs.sensors. Use st2sensorcontainer.postStartScript instead.
+      #
+      # This example only defines name and ref, accepting all defaults in st2sensorcontainer:
+      # - name: some-sensor-node
+      #   ref: some_pack.some_sensor
+      #
+      # This example also uses a custom image tag:
+      # - name: another-sensor-node
+      #   ref: some_pack.another_sensor
+      #   image:
+      #     tag: 3.5.0-another_sensor-r1
+
   # Import data into StackStorm's Key/Value datastore (https://docs.stackstorm.com/datastore.html)
   keyvalue:
     #- name: st2_version
@@ -535,8 +528,11 @@ st2actionrunner:
   postStartScript: ""
 
 # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
-# Please see st2.packs.sensors for each sensor instance's config.
-# This contains default settings for all sensor pods.
+# It is possible to run st2sensorcontainer(s) in one of these modes:
+#   (1) run all sensors in one pod (1 deployment with 1 pod, the default); or
+#   (2) run one sensor per pod using st2.packs.sensors (see above).
+# To use the default mode (all sensors in one pod), st2.packs.sensors must be empty.
+# For one-sensor-per-pod, define defaults here and add config for each sensor to st2.packs.sensors (above).
 st2sensorcontainer:
   resources:
     requests:


### PR DESCRIPTION
This makes it safer to configure `one-sensor-per-pod` mode, because it will error if `ref` is not defined when it should be. This way people cannot accidentally create multiple pods in `all-sensors-in-one-pod` mode.

`one-sensor-per-pod`:

-  Uses `st2.packs.sensors`, defaults come from `st2sensorcontainer`.
-  Require `ref` for every sensor in `st2.packs.sensors`.

`all-sensors-in-one-pod`:

-  Only use `st2sensorcontainer` for the only pod.
-  Ignore `st2.packs.sensors` in this mode.
-  No more magic first element in `st2.packs.sensors` to enable this.

Examples in `values.yaml` updated to be more focused.