### PR TITLE
Do not include default rbac files in values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Explicitly differentiate sensor modes: `all-sensors-in-one-pod` vs `one-sensor-per-pod`. Exposes the mode in new `stackstorm/sensor-mode` annotation. (#222) (by @cognifloyd)
 * Allow adding custom env variables to any Deployment or Job. (#120) (by @AngryDeveloper)
+* Remove default/sample RBAC config files from default values because they cannot be removed by overriding the roles/mappings values. (#247) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/values.yaml
+++ b/values.yaml
@@ -206,30 +206,31 @@ st2:
     enabled: false
     # Custom StackStorm RBAC roles, shipped in '/opt/stackstorm/rbac/roles/'
     # See https://docs.stackstorm.com/rbac.html#defining-roles-and-permission-grants
-    roles:
-      sample.yaml: |
-        # sample RBAC role file, see https://docs.stackstorm.com/rbac.html#defining-roles-and-permission-grants
-        ---
-        name: "sample"
-        description: "Example Role which contains no permission grants and serves for demonstration purposes"
+    roles: {}
+      #sample.yaml: |
+      #  # sample RBAC role file, see https://docs.stackstorm.com/rbac.html#defining-roles-and-permission-grants
+      #  ---
+      #  name: "sample"
+      #  description: "Example Role which contains no permission grants and serves for demonstration purposes"
 
     # Custom StackStorm RBAC role assignments, shipped in '/opt/stackstorm/rbac/assignments/'
+    # When using RBAC, make sure to define assignments for system users like st2admin and stanley.
     # See: https://docs.stackstorm.com/rbac.html#defining-user-role-assignments
-    assignments:
-      st2admin.yaml: |
-        ---
-        username: st2admin
-        roles:
-          - system_admin
-      stanley.yaml: |
-        ---
-        username: stanley
-        roles:
-          - admin
+    assignments: {}
+      #st2admin.yaml: |
+      #  ---
+      #  username: st2admin
+      #  roles:
+      #    - system_admin
+      #stanley.yaml: |
+      #  ---
+      #  username: stanley
+      #  roles:
+      #    - admin
 
     # StackStorm RBAC LDAP groups-to-roles mapping rules, shipped in '/opt/stackstorm/rbac/mappings/'
     # See RBAC Roles Based on LDAP Groups: https://docs.stackstorm.com/rbac.html#automatically-granting-roles-based-on-ldap-group-membership
-    mappings:
+    mappings: {}
       #stormers.yaml: |
       #  ---
       #  group: "CN=stormers,OU=groups,DC=stackstorm,DC=net"


### PR DESCRIPTION
As values dictionaries are merged, there is no way to remove unwanted rbac files like sample.yaml. And, we cannot assume that st2admin and stanley are present, because those are configurable. So, do not include any sample/default rbac files in values.

Resolves #230
Closes #248 (alternative implementation)