### PR TITLE
Allow excluding default/sample RBAC files in values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Explicitly differentiate sensor modes: `all-sensors-in-one-pod` vs `one-sensor-per-pod`. Exposes the mode in new `stackstorm/sensor-mode` annotation. (#222) (by @cognifloyd)
 * Allow adding custom env variables to any Deployment or Job. (#120) (by @AngryDeveloper)
+* Set default/sample RBAC config files to "" (empty string) to prevent adding them. This is needed because they cannot be removed by overriding the roles/mappings values. (#247) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/configmaps_rbac.yaml
+++ b/templates/configmaps_rbac.yaml
@@ -14,7 +14,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{ toYaml .Values.st2.rbac.roles | indent 2 }}
+{{- range $filename, $contents := .Values.st2.rbac.roles }}
+  {{/* to support removing default files, skip files with empty contents */}}
+  {{- if $contents }}
+  {{ $filename }}: |
+    {{- $contents | nindent 4 }}
+  {{- end }}
+{{- end }}
 
 ---
 apiVersion: v1
@@ -31,7 +37,13 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 data:
-{{ toYaml .Values.st2.rbac.assignments | indent 2 }}
+{{- range $filename, $contents := .Values.st2.rbac.assignments }}
+  {{/* to support removing default files, skip files with empty contents */}}
+  {{- if $contents }}
+  {{ $filename }}: |
+    {{- $contents | nindent 4 }}
+  {{- end }}
+{{- end }}
 
 ---
 apiVersion: v1

--- a/values.yaml
+++ b/values.yaml
@@ -207,6 +207,7 @@ st2:
     # Custom StackStorm RBAC roles, shipped in '/opt/stackstorm/rbac/roles/'
     # See https://docs.stackstorm.com/rbac.html#defining-roles-and-permission-grants
     roles:
+      # TIP: set files to an empty string to remove them (sample.yaml: "")
       sample.yaml: |
         # sample RBAC role file, see https://docs.stackstorm.com/rbac.html#defining-roles-and-permission-grants
         ---
@@ -216,6 +217,7 @@ st2:
     # Custom StackStorm RBAC role assignments, shipped in '/opt/stackstorm/rbac/assignments/'
     # See: https://docs.stackstorm.com/rbac.html#defining-user-role-assignments
     assignments:
+      # TIP: set files to an empty string to remove them (st2admin.yaml: "")
       st2admin.yaml: |
         ---
         username: st2admin


### PR DESCRIPTION
As values dictionaries are merged, there is no way to remove unwanted rbac files like sample.yaml. And, we cannot assume that st2admin and stanley are present, because those are configurable.

So, we allow the user to set the sample/default files to an empty string to prevent them from inclusion in their stackstorm-ha cluster.

Resolves #230
Closes #247 (alternative implementation)