### PR TITLE
Feature: custom volumes (for secrets, etc) on st2actionrunner pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Template the contents of st2.config and the values in st2chatops.env. This allows adding secrets defined elsewhere in values. (#249) (by @cognifloyd)
 * Set default/sample RBAC config files to "" (empty string) to prevent adding them. This is needed because they cannot be removed by overriding the roles/mappings values. (#247) (by @cognifloyd)
 * Make configuring `stackstorm/sensor-mode=all-sensors-in-one-pod` more obvious by using `st2.packs.sensors` only for `one-sensor-per-pod`. `all-sensors-in-one-pod` mode now only uses values from `st2sensorcontainer`. (#246) (by @cognifloyd)
+* New feature: Add `extra_volumes` to `st2actionrunner`, `st2client`, `st2sensorcontainer`. This is useful for loading volumes to be used by actions or sensors. This might include secrets (like ssl certificates) and configuration (like system-wide ansible.cfg). (#254) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -764,6 +764,10 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
+        {{- range .Values.st2workflowengine.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2workflowengine.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2workflowengine.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2workflowengine.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -787,6 +791,10 @@ spec:
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
+        {{- range .Values.st2workflowengine.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2workflowengine.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2workflowengine.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.st2workflowengine.postStartScript }}
         - name: st2-post-start-script-vol

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1124,7 +1124,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- range .extra_volumes }}
+        {{- range $sensor.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in $sensor.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in $sensor.extra_volumes" .mount | toYaml) $ | nindent 10 }}
         {{- end }}
@@ -1153,7 +1153,7 @@ spec:
         {{- end }}
         {{- include "st2-config-volume" $ | nindent 8 }}
         {{- include "packs-volumes" $ | nindent 8 }}
-        {{- range .extra_volumes }}
+        {{- range $sensor.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in $sensor.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in $sensor.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1124,6 +1124,10 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
+        {{- range .extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in $sensor.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in $sensor.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if $.Values.st2sensorcontainer.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -1149,6 +1153,10 @@ spec:
         {{- end }}
         {{- include "st2-config-volume" $ | nindent 8 }}
         {{- include "packs-volumes" $ | nindent 8 }}
+        {{- range .extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in $sensor.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in $sensor.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if $.Values.st2sensorcontainer.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1255,6 +1263,10 @@ spec:
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "pack-configs-volume-mount" . | nindent 8 }}
         {{- end }}
+        {{- range .Values.st2actionrunner.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2actionrunner.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2actionrunner.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
           subPath: post-start.sh
@@ -1288,6 +1300,10 @@ spec:
         {{- include "packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "pack-configs-volume" . | nindent 8 }}
+        {{- end }}
+        {{- range .Values.st2actionrunner.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2actionrunner.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2actionrunner.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1520,6 +1536,10 @@ spec:
         {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- include "pack-configs-volume-mount" . | nindent 8 }}
+        {{- range .Values.st2client.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2client.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
           subPath: post-start.sh
@@ -1569,6 +1589,10 @@ spec:
               mode: 256
         {{- include "packs-volumes" . | nindent 8 }}
         {{- include "pack-configs-volume" . | nindent 8 }}
+        {{- range .Values.st2client.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2client.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
         - name: st2-post-start-script-vol
           configMap:
             name: {{ .Release.Name }}-st2client-post-start-script

--- a/values.yaml
+++ b/values.yaml
@@ -461,6 +461,10 @@ st2workflowengine:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2workflowengine pod(s) (primarily useful for k8s-provisioned secrets)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2workflowengine.extra_volumes
 # https://docs.stackstorm.com/reference/ha.html#st2scheduler
 # TODO: Description TBD
 st2scheduler:

--- a/values.yaml
+++ b/values.yaml
@@ -549,6 +549,32 @@ st2actionrunner:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2actionrunner pods (primarily useful for k8s-provisioned secrets)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # For example, if some actions in the fictional acme pack
+    # needed some file-based client-side certificates:
+    # - name: st2-encryption-key-vol
+    #   mount:
+    #     mountPath: "{{ .Values.acme.ssl_certs_dir }}"
+    #     readOnly: true
+    #   volume:
+    #     secret:
+    #       secretName: "{{ .Release.Name }}-st2-acme-pack-certs"
+    #       items:
+    #       - key: ssl_certificate
+    #         path: acme.crt
+    #       - key: ssl_certificate_key
+    #         path: acme.key
+    #
+    # An example that adds a global ansible.cfg file for the ansible pack.
+    # - name: global-ansible-config
+    #   mount:
+    #     mountPath: /etc/ansible/ansible.cfg
+    #     subPath: ansible.cfg
+    #   volume:
+    #     configMap:
+    #       name: "{{ .Release.Name }}-st2-ansible-config"
 
 # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
 # It is possible to run st2sensorcontainer(s) in one of these modes:
@@ -581,6 +607,10 @@ st2sensorcontainer:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2sensorcontainer pod(s) (primarily useful for k8s-provisioned secrets)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
 
 # The st2client deployment/pod simplifies ad-hoc administration.
 # st2client is a special purpose actionrunner pod, but you can customize it separately
@@ -597,6 +627,10 @@ st2client:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2client pod (primarily useful for k8s-provisioned secrets)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
 
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.


### PR DESCRIPTION
Add `extra_volumes` to `st2actionrunner`, `st2client`, `st2sensorcontainer`. This is useful for loading volumes to be used by actions or sensors. This might include secrets (like ssl certificates) and configuration (like system-wide ansible.cfg).

Closes #212