### PR TITLE
Optional upgrade jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Make configuring `stackstorm/sensor-mode=all-sensors-in-one-pod` more obvious by using `st2.packs.sensors` only for `one-sensor-per-pod`. `all-sensors-in-one-pod` mode now only uses values from `st2sensorcontainer`. (#246) (by @cognifloyd)
 * Use "--convert" when loading keys into datastore (in key-load Job) so that `st2.keyvalue[].value` can be any basic JSON data type. (#253) (by @cognifloyd)
 * New feature: Add `extra_volumes` to `st2actionrunner`, `st2client`, `st2sensorcontainer`. This is useful for loading volumes to be used by actions or sensors. This might include secrets (like ssl certificates) and configuration (like system-wide ansible.cfg). (#254) (by @cognifloyd)
+* Some `helm upgrades` do not need to run all the jobs. An upgrade that only touches RBAC config, for example, does not need to run the register-content job. Use `--set jobs.default_hooks.register_content=false` to skip the register-content job. Do likewise for other jobs that you'd like to skip. (#255) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.st2.rbac.enabled -}}
+{{- if and .Values.st2.rbac.enabled .Values.jobs.default_hooks.apply_rbac_definitions -}}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -90,6 +90,7 @@ spec:
     {{- end }}
 
 {{- end }}
+{{- if .Values.jobs.default_hooks.apikey_load }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -218,6 +219,8 @@ spec:
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
 
+{{- end }}
+{{- if .Values.jobs.default_hooks.key_load }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -340,6 +343,8 @@ spec:
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
 
+{{- end }}
+{{- if .Values.jobs.default_hooks.register_content }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -441,3 +446,5 @@ spec:
     {{- with .Values.jobs.tolerations }}
       tolerations: {{- toYaml . | nindent 8 }}
     {{- end }}
+
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -741,6 +741,16 @@ jobs:
   affinity: {}
   env: {}
   # HTTP_PROXY: http://proxy:1234
+  #
+  # Advanced controls for the default hook jobs. If false, the jobs will not be created.
+  # Generally, leave these set to true.
+  # Example use case: Do not run register_content when an upgrade only touches rbac_definitions.
+  #   helm upgrade ... --set jobs.default_hooks.register_content=false ...
+  default_hooks:
+    apply_rbac_definitions: true
+    apikey_load: true
+    key_load: true
+    register_content: true
 
 ##
 ## MongoDB HA configuration (3rd party chart dependency)


### PR DESCRIPTION
Some `helm upgrades` do not need to run all the jobs. An upgrade that only touches RBAC config, for example, does not need to run the register-content job. Use `--set jobs.default_hooks.register_content=false` to skip the register-content job. Do likewise for other jobs that you'd like to skip.

Closes #226