### PR TITLE
Add jobs.api_key so jobs can use api_key instead of username/password

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Use "--convert" when loading keys into datastore (in key-load Job) so that `st2.keyvalue[].value` can be any basic JSON data type. (#253) (by @cognifloyd)
 * New feature: Add `extra_volumes` to `st2actionrunner`, `st2client`, `st2sensorcontainer`. This is useful for loading volumes to be used by actions or sensors. This might include secrets (like ssl certificates) and configuration (like system-wide ansible.cfg). (#254) (by @cognifloyd)
 * Some `helm upgrades` do not need to run all the jobs. An upgrade that only touches RBAC config, for example, does not need to run the register-content job. Use `--set 'jobs.skip={apikey_load,key_load,register_content}'` to skip the other jobs. (#255) (by @cognifloyd)
+* Improve `helm upgrade` so that automated upgrade jobs can use a StackStorm API key instead of username/password. Create an `apikey` in your StackStorm instance, just for helm, and then add the key to your values file under `jobs.api_key`. (#256) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -149,6 +149,13 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         env:
+        {{- if .Values.jobs.api_key }}
+        - name: ST2_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-st2-auth
+              key: jobs_api_key
+        {{- else }}
         - name: ST2_AUTH_USERNAME
           valueFrom:
             secretKeyRef:
@@ -159,6 +166,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-st2-auth
               key: password
+        {{- end }}
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
@@ -169,8 +177,12 @@ spec:
           - |
             cat <<EOT > /root/.st2/config
             [credentials]
+            {{- if .Values.jobs.api_key }}
+            api_key = ${ST2_API_KEY}
+            {{- else }}
             username = ${ST2_AUTH_USERNAME}
             password = ${ST2_AUTH_PASSWORD}
+            {{- end }}
             EOT
       containers:
       - name: st2-apikey-load
@@ -270,6 +282,13 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         env:
+        {{- if .Values.jobs.api_key }}
+        - name: ST2_API_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ .Release.Name }}-st2-auth
+              key: jobs_api_key
+        {{- else }}
         - name: ST2_AUTH_USERNAME
           valueFrom:
             secretKeyRef:
@@ -280,6 +299,7 @@ spec:
             secretKeyRef:
               name: {{ .Release.Name }}-st2-auth
               key: password
+        {{- end }}
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
@@ -290,8 +310,12 @@ spec:
           - |
             cat <<EOT > /root/.st2/config
             [credentials]
+            {{- if .Values.jobs.api_key }}
+            api_key = ${ST2_API_KEY}
+            {{- else }}
             username = ${ST2_AUTH_USERNAME}
             password = ${ST2_AUTH_PASSWORD}
+            {{- end }}
             EOT
       containers:
       - name: st2-key-load

--- a/templates/secrets_st2auth.yaml
+++ b/templates/secrets_st2auth.yaml
@@ -30,3 +30,7 @@ data:
 {{ else }}
   password: {{ default (randAlphaNum 12) .Values.st2.password | b64enc | quote }}
 {{ end }}
+{{- if .Values.jobs.api_key }}
+  # api_key used by helm Jobs to login to StackStorm (instead of username/password)
+  jobs_api_key: {{ .Values.jobs.api_key | b64enc | quote }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -718,6 +718,11 @@ st2chatops:
 ## Various batch jobs (apply-rbac-definitions, apikey-load, key-load, register-content)
 ##
 jobs:
+  # For jobs that need to use the ST2 APIs, if you set jobs.api_key
+  # then the jobs will use jobs.api_key instead of st2.username/st2.password
+  # This is only useful when running `helm upgrade` as the api_key must be present
+  # before the apikey-load job runs (it will use this api_key if defined).
+  api_key:
   annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   # The Jobs use the st2actionrunner image

--- a/values.yaml
+++ b/values.yaml
@@ -725,11 +725,10 @@ st2chatops:
 ## Various batch jobs (apply-rbac-definitions, apikey-load, key-load, register-content)
 ##
 jobs:
-  # For jobs that need to use the ST2 APIs, if you set jobs.api_key
-  # then the jobs will use jobs.api_key instead of st2.username/st2.password
-  # This is only useful when running `helm upgrade` as the api_key must be present
-  # before the apikey-load job runs (it will use this api_key if defined).
-  api_key:
+  # The st2-key-load and st2-apikey-load jobs use the ST2 APIs to load keys and apikeys (respectively.
+  # If defined, `jobs.api_key` will be used for `helm upgrades` instead of `st2.username` and `st2.password`.
+  # Make sure to add this api_key during `helm install` so that it is available during upgrades.
+  api_key: ""
   annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   # The Jobs use the st2actionrunner image


### PR DESCRIPTION
I always insist that automated jobs use API keys instead of username/password. This allows using an st2 API key with the helm hook jobs during `helm upgrade`. Just set `jobs.api_key` to a key that you created for helm to use.

Closes #233
