### PR TITLE
allow bypassing generate-st2client-config init container for st2client and jobs pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Some `helm upgrades` do not need to run all the jobs. An upgrade that only touches RBAC config, for example, does not need to run the register-content job. Use `--set 'jobs.skip={apikey_load,key_load,register_content}'` to skip the other jobs. (#255) (by @cognifloyd)
 * Refactor deployments/jobs to inject st2 username/password via `envFrom` instead of via `env`. (#257) (by @cognifloyd)
 * New feature: Add `envFromSecrets` to `st2actionrunner`, `st2client`, `st2sensorcontainer`, and jobs. This is useful for adding custom secrets to the environment. This complements the `extra_volumes` feature (loading secrets as files) to facilitate loading secrets that are not easily injected via the filesystem. (#259) (by @cognifloyd)
+* Add `st2client.generateST2ClientConfig` and `jobs.generateST2ClientConfig` to allow excluding the `generate-st2client-config` initContainer from st2client and/or jobs. Normally, that initContainer creates the `/root/.st2/config` file. If you provide your own `/root/.st2/config` file via `extra_volumes`, or if you provide an `ST2_API_KEY` or `ST2_AUTH_TOKEN` via `envFromSecrets` for the jobs to use, then you should set the relevant `generateST2ClientConfig` setting to false. (#261) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1481,6 +1481,7 @@ spec:
       {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
         {{- include "packs-initContainers" . | nindent 6 }}
       {{- end }}
+      {{- if .Values.st2client.generateST2ClientConfig }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
@@ -1503,6 +1504,7 @@ spec:
             username = ${ST2_AUTH_USERNAME}
             password = ${ST2_AUTH_PASSWORD}
             EOT
+      {{- end }}
       containers:
       - name: st2client
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
@@ -1528,8 +1530,10 @@ spec:
         - name: st2-rbac-mappings-vol
           mountPath: /opt/stackstorm/rbac/mappings/
         {{- end }}
+        {{- if .Values.st2client.generateST2ClientConfig }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
+        {{- end }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
         {{- if .Values.st2.datastore_crypto_key }}
@@ -1579,9 +1583,11 @@ spec:
           configMap:
             name: {{ .Release.Name }}-st2-rbac-mappings
         {{- end }}
+        {{- if .Values.st2client.generateST2ClientConfig }}
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
+        {{- end }}
         - name: st2-ssh-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-ssh

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -148,6 +148,7 @@ spec:
             until nc -z -w 2 {{ .Release.Name }}-st2api 9101 && echo st2api ready;
               do sleep 2;
             done
+      {{- if .Values.jobs.generateST2ClientConfig }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
@@ -170,6 +171,7 @@ spec:
             username = ${ST2_AUTH_USERNAME}
             password = ${ST2_AUTH_PASSWORD}
             EOT
+      {{- end }}
       containers:
       - name: st2-apikey-load
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
@@ -190,17 +192,21 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
+        {{- if .Values.jobs.generateST2ClientConfig }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
+        {{- end }}
         - name: st2-apikeys-vol
           mountPath: /etc/st2/apikeys.yaml
           subPath: apikeys.yaml
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
+        {{- if .Values.jobs.generateST2ClientConfig }}
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
+        {{- end }}
         - name: st2-apikeys-vol
           secret:
             secretName: {{ .Release.Name }}-st2-apikeys
@@ -264,6 +270,7 @@ spec:
       {{- end }}
       initContainers:
       {{- include "init-containers-wait-for-db" . | nindent 6 }}
+      {{- if .Values.jobs.generateST2ClientConfig }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
@@ -286,6 +293,7 @@ spec:
             username = ${ST2_AUTH_USERNAME}
             password = ${ST2_AUTH_PASSWORD}
             EOT
+      {{- end }}
       containers:
       - name: st2-key-load
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
@@ -308,8 +316,10 @@ spec:
         {{- end }}
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.jobs.generateST2ClientConfig }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
+        {{- end }}
         - name: st2-kv-vol
           mountPath: /etc/st2/st2kv.yaml
           subPath: st2kv.yaml
@@ -317,9 +327,11 @@ spec:
         #resources:
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
+        {{- if .Values.jobs.generateST2ClientConfig }}
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
+        {{- end }}
         - name: st2-kv-vol
           secret:
             secretName: {{ .Release.Name }}-st2-kv

--- a/values.yaml
+++ b/values.yaml
@@ -641,6 +641,10 @@ st2client:
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
     # see examples under st2actionrunner.extra_volumes
+  # By default the the st2client pod generates /root/.st2/config based on st2.username/st2.password.
+  # If you are providing credentials via envFromSecrets, or providing that file in extra_volumes,
+  # you can skip creating that st2 config file by setting this to false.
+  generateST2ClientConfig: true
 
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.
@@ -757,6 +761,9 @@ jobs:
   # For example, if an upgrade only touches RBAC config, use this to disable other jobs:
   #   helm upgrade ... --set 'jobs.skip={apikey_load,key_load,register_content}'
   skip: []
+  # By default the apikey_load and key_load jobs generate /root/.st2/config based on st2.username/st2.password.
+  # If you are providing credentials via envFromSecrets, you can skip creating that file by setting this to false.
+  generateST2ClientConfig: true
 
 ##
 ## MongoDB HA configuration (3rd party chart dependency)


### PR DESCRIPTION
This allows users who pass credentials via extra_volumes or envFromSecrets to bypass the `generate-st2client-config` initContainer.

This adds two boolean values: `st2client.generateST2ClientConfig` and `jobs.generateST2ClientConfig`. By setting `generateST2ClientConfig` to false, users can exclude the `generate-st2client-config` initContainer from st2client and/or jobs. Normally, that initContainer creates the `/root/.st2/config` file. Users may want to skip that initContainer when they:
- provide their own `/root/.st2/config` file via `extra_volumes`; or
- provide an `ST2_API_KEY` or `ST2_AUTH_TOKEN` via `envFromSecrets`.

Closes #233
Closes #256

Note: This PR is an alternate implementation of #256. (and I prefer this implementation over #256)
I want to provide the `ST2_API_KEY` via `envFromSecrets`, but the `/root/.st2/client` config with a `username` takes precedence over the `ST2_API_KEY` env var. When I looked into using `kustomize` I couldn't find a reliable way to remove the relevant initContainers. `jsonPatch` relies on array indexes which would be very brittle, and merge stragety patches can't remove items from an array. So, this PR provides a simple flag to exclude the initContainers in question.
