### PR TITLE
template st2client conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Some `helm upgrades` do not need to run all the jobs. An upgrade that only touches RBAC config, for example, does not need to run the register-content job. Use `--set 'jobs.skip={apikey_load,key_load,register_content}'` to skip the other jobs. (#255) (by @cognifloyd)
 * Refactor deployments/jobs to inject st2 username/password via `envFrom` instead of via `env`. (#257) (by @cognifloyd)
 * New feature: Add `envFromSecrets` to `st2actionrunner`, `st2client`, `st2sensorcontainer`, and jobs. This is useful for adding custom secrets to the environment. This complements the `extra_volumes` feature (loading secrets as files) to facilitate loading secrets that are not easily injected via the filesystem. (#259) (by @cognifloyd)
+* Template `~/.st2/config`. This allows customizing the settings used by the `st2client` and jobs pods for using the st2 apis. (#262) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1499,9 +1499,7 @@ spec:
           - '-ec'
           - |
             cat <<EOT > /root/.st2/config
-            [credentials]
-            username = ${ST2_AUTH_USERNAME}
-            password = ${ST2_AUTH_PASSWORD}
+            {{- tpl .Values.st2client.st2clientConfig . | nindent 12 }}
             EOT
       containers:
       - name: st2client

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1490,6 +1490,10 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         - secretRef:
             name: {{ .Release.Name }}-st2-auth
+        {{- range .Values.st2client.envFromSecrets }}
+        - secretRef:
+            name: {{ . }}
+        {{- end }}
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -157,6 +157,10 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         - secretRef:
             name: {{ .Release.Name }}-st2-auth
+        {{- range .Values.jobs.envFromSecrets }}
+        - secretRef:
+            name: {{ . }}
+        {{- end }}
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/
@@ -271,6 +275,10 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         - secretRef:
             name: {{ .Release.Name }}-st2-auth
+        {{- range .Values.jobs.envFromSecrets }}
+        - secretRef:
+            name: {{ . }}
+        {{- end }}
         volumeMounts:
         - name: st2client-config-vol
           mountPath: /root/.st2/

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -166,9 +166,7 @@ spec:
           - '-ec'
           - |
             cat <<EOT > /root/.st2/config
-            [credentials]
-            username = ${ST2_AUTH_USERNAME}
-            password = ${ST2_AUTH_PASSWORD}
+            {{- tpl .Values.jobs.st2clientConfig . | nindent 12 }}
             EOT
       containers:
       - name: st2-apikey-load
@@ -282,9 +280,7 @@ spec:
           - '-ec'
           - |
             cat <<EOT > /root/.st2/config
-            [credentials]
-            username = ${ST2_AUTH_USERNAME}
-            password = ${ST2_AUTH_PASSWORD}
+            {{- tpl .Values.jobs.st2clientConfig . | nindent 12 }}
             EOT
       containers:
       - name: st2-key-load

--- a/values.yaml
+++ b/values.yaml
@@ -623,7 +623,7 @@ st2sensorcontainer:
 # The st2client deployment/pod simplifies ad-hoc administration.
 # st2client is a special purpose actionrunner pod, but you can customize it separately
 st2client:
-  # st2client config (~/.st2/config) template for jobs that need it.
+  # st2client config (~/.st2/config) template.
   # You can access env variables here because this is used in a bash heredoc.
   # For example, you could use a var injected with envFromSecrets.
   # Note that Helm templating is supported in this block!

--- a/values.yaml
+++ b/values.yaml
@@ -624,6 +624,7 @@ st2sensorcontainer:
 # st2client is a special purpose actionrunner pod, but you can customize it separately
 st2client:
   # st2client config (~/.st2/config) template.
+  # see: https://docs.stackstorm.com/reference/cli.html#configuration-file
   # You can access env variables here because this is used in a bash heredoc.
   # For example, you could use a var injected with envFromSecrets.
   # Note that Helm templating is supported in this block!
@@ -738,6 +739,7 @@ st2chatops:
 ##
 jobs:
   # st2client config (~/.st2/config) template for jobs that need it.
+  # see: https://docs.stackstorm.com/reference/cli.html#configuration-file
   # You can access env variables here because this is used in a bash heredoc.
   # For example, you could use a var injected with envFromSecrets.
   # Note that Helm templating is supported in this block!

--- a/values.yaml
+++ b/values.yaml
@@ -623,6 +623,14 @@ st2sensorcontainer:
 # The st2client deployment/pod simplifies ad-hoc administration.
 # st2client is a special purpose actionrunner pod, but you can customize it separately
 st2client:
+  # st2client config (~/.st2/config) template for jobs that need it.
+  # You can access env variables here because this is used in a bash heredoc.
+  # For example, you could use a var injected with envFromSecrets.
+  # Note that Helm templating is supported in this block!
+  st2clientConfig: |
+    [credentials]
+    username = ${ST2_AUTH_USERNAME}
+    password = ${ST2_AUTH_PASSWORD}
   env: {}
   # HTTP_PROXY: http://proxy:1234
   ## These named secrets (managed outside this chart) will be added to envFrom.
@@ -725,6 +733,14 @@ st2chatops:
 ## Various batch jobs (apply-rbac-definitions, apikey-load, key-load, register-content)
 ##
 jobs:
+  # st2client config (~/.st2/config) template for jobs that need it.
+  # You can access env variables here because this is used in a bash heredoc.
+  # For example, you could use a var injected with envFromSecrets.
+  # Note that Helm templating is supported in this block!
+  st2clientConfig: |
+    [credentials]
+    username = ${ST2_AUTH_USERNAME}
+    password = ${ST2_AUTH_PASSWORD}
   annotations: {}
   # Override default image settings (for now, only tag can be overridden)
   # The Jobs use the st2actionrunner image


### PR DESCRIPTION
This moves the `/root/.st2/config` template (a bash heredoc) to values so that it can be adjusted based on install requirements. This also makes secrets in `envFromSecrets` available to the `generate-st2client-config` initContainers so that they can be used within the bash heredoc template. The template value is also passed through `tpl` to support helm templating for any non-secret config such as injecting the timezone.

Relevant st2 docs on the st2client config file: https://docs.stackstorm.com/reference/cli.html#configuration-file

Closes #233
Closes #256
Closes #261

Note: This PR is an alternate implementation of #256 and #261 based on @armab's feedback in #261.
I want to provide the `ST2_API_KEY` via `envFromSecrets`, but the `/root/.st2/client` config with a `username` takes precedence over the `ST2_API_KEY` env var. Templating the file allows me to either inject the api_key in the config file, or remove the credentials so that the `ST2_API_KEY` var is used.
