### PR TITLE
Generate datastore_crypto_key on install if not provided

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
   helm-lint:
     working_directory: ~/stackstorm-ha
     docker:
-      - image: lachlanevenson/k8s-helm:v3.4.2
+      - image: lachlanevenson/k8s-helm:v3.5.0
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ jobs:
   helm-lint:
     working_directory: ~/stackstorm-ha
     docker:
-      - image: lachlanevenson/k8s-helm:v3.5.0
+      - image: lachlanevenson/k8s-helm:v3.5.3
     steps:
       - checkout
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Fix indent for lifecycle postStart hook of `st2web` pod. (#268) (by @cognifloyd)
 * Advanced Feature: Allow `st2web` to serve HTTPS when the ssl certs are provided via `st2web.extra_volumes`. To enable this, add `ST2WEB_HTTPS: "1"` to `st2web.env` in your values file. (#264) (by @cognifloyd)
 * Custom annotations now apply to deployments and jobs, not just pods. (#270) (by @cognifloyd)
-* Auto-generate `datastore_crypto_key` on install if not provided. This way all HA installs will have a datastore_crypto_key configured. (#266) (by @cognifloyd)
+* BREAKING CHANGE: Auto-generate `datastore_crypto_key` on install if not provided. This way all HA installs will have a datastore_crypto_key configured. This is only a breaking change for installations that do not want a `datastore_crypto_key`. To disable set `datastore_crypto_key` to `disable` instead of setting it to `""`, `null`, or leaving it unset. (#266) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * New feature: Add `envFromSecrets` to `st2actionrunner`, `st2client`, `st2sensorcontainer`, and jobs. This is useful for adding custom secrets to the environment. This complements the `extra_volumes` feature (loading secrets as files) to facilitate loading secrets that are not easily injected via the filesystem. (#259) (by @cognifloyd)
 * New feature to include `nodeSelector`, `affinity` and `tolerations` to `st2client`, allowing more flexibility to pod positioning. (#263) (by @sandesvitor)
 * Template `~/.st2/config`. This allows customizing the settings used by the `st2client` and jobs pods for using the st2 apis. (#262) (by @cognifloyd)
+* Auto-generate `datastore_crypto_key` on install if not provided. This way all HA installs will have a datastore_crypto_key configured. (#266) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It's more than welcome to fine-tune each component settings to fit specific avai
 
 ## Requirements
 * [Kubernetes](https://kubernetes.io/docs/setup/pick-right-solution/) cluster
-* [Helm](https://docs.helm.sh/using_helm/#install-helm) `v3.x`
+* [Helm](https://docs.helm.sh/using_helm/#install-helm) `v3.5` or greater
 
 ## Usage
 1) Edit `values.yaml` with configuration for the StackStorm HA K8s cluster.

--- a/conf/datastore_crypto_key.yaml
+++ b/conf/datastore_crypto_key.yaml
@@ -1,0 +1,13 @@
+# This is used to generate st2.datastore_crypto_key on install if not defined in values.
+
+# The formula is based on an st2-specific version of python's base64.urlsafe_b64encode
+# randBytes returns a base64 encoded string
+# 32 bytes = 256 bits / 8 bits/byte
+
+aesKeyString: '{{ randBytes 32 | replace "+" "-" | replace "_" "/" | replace "=" "" }}'
+mode: CBC
+size: 256
+
+hmacKey:
+  hmacKeyString: '{{ randBytes 32 | replace "+" "-" | replace "_" "/" | replace "=" "" }}'
+  size: 256

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -42,10 +42,8 @@ data:
     {{- end }}
     port = {{ index .Values "mongodb" "service" "port" }}
     {{- end }}
-    {{- if .Values.st2.datastore_crypto_key }}
     [keyvalue]
     encryption_key_path = /etc/st2/keys/datastore_key.json
-    {{- end }}
     {{- if .Values.st2.rbac.enabled }}
     [rbac]
     enable = True

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -42,8 +42,10 @@ data:
     {{- end }}
     port = {{ index .Values "mongodb" "service" "port" }}
     {{- end }}
+    {{- if .Values.st2.datastore_crypto_key }}
     [keyvalue]
     encryption_key_path = /etc/st2/keys/datastore_key.json
+    {{- end }}
     {{- if .Values.st2.rbac.enabled }}
     [rbac]
     enable = True

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -42,7 +42,7 @@ data:
     {{- end }}
     port = {{ index .Values "mongodb" "service" "port" }}
     {{- end }}
-    {{- if .Values.st2.datastore_crypto_key }}
+    {{- if ne "disable" .Values.st2.datastore_crypto_key }}
     [keyvalue]
     encryption_key_path = /etc/st2/keys/datastore_key.json
     {{- end }}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -42,7 +42,7 @@ data:
     {{- end }}
     port = {{ index .Values "mongodb" "service" "port" }}
     {{- end }}
-    {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+    {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
     [keyvalue]
     encryption_key_path = /etc/st2/keys/datastore_key.json
     {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -204,7 +204,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -228,7 +228,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -565,7 +565,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -586,7 +586,7 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -780,7 +780,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -805,7 +805,7 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -901,7 +901,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -921,7 +921,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -1161,7 +1161,7 @@ spec:
         volumeMounts:
         {{- include "st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "packs-volume-mounts" $ | nindent 8 }}
-        {{- if ne "disable" $.Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" $.Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -1185,7 +1185,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" $ }}
     {{- end }}
       volumes:
-        {{- if ne "disable" $.Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" $.Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ $.Release.Name }}-st2-datastore-crypto-key
@@ -1303,7 +1303,7 @@ spec:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -1329,7 +1329,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -1581,7 +1581,7 @@ spec:
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -1608,7 +1608,7 @@ spec:
             memory: "5Mi"
             cpu: "5m"
       volumes:
-        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -204,7 +204,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -228,7 +228,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -565,7 +565,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -586,7 +586,7 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -780,7 +780,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -805,7 +805,7 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -901,7 +901,7 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -921,7 +921,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -1161,7 +1161,7 @@ spec:
         volumeMounts:
         {{- include "st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "packs-volume-mounts" $ | nindent 8 }}
-        {{- if $.Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" $.Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -1185,7 +1185,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" $ }}
     {{- end }}
       volumes:
-        {{- if $.Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" $.Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ $.Release.Name }}-st2-datastore-crypto-key
@@ -1303,7 +1303,7 @@ spec:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -1329,7 +1329,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
@@ -1581,7 +1581,7 @@ spec:
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
@@ -1608,7 +1608,7 @@ spec:
             memory: "5Mi"
             cpu: "5m"
       volumes:
-        {{- if .Values.st2.datastore_crypto_key }}
+        {{- if ne "disable" .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -198,11 +198,9 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
-        {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "pack-configs-volume-mount" . | nindent 8 }}
@@ -222,14 +220,12 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
-        {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         {{- include "packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
@@ -542,11 +538,9 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
-        {{- end }}
         {{- if .Values.st2rulesengine.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -563,14 +557,12 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
-        {{- end }}
         {{- if .Values.st2rulesengine.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -751,11 +743,9 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
-        {{- end }}
         {{- range .Values.st2workflowengine.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2workflowengine.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in st2workflowengine.extra_volumes" .mount | toYaml) $ | nindent 10 }}
@@ -776,14 +766,12 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
-        {{- end }}
         {{- range .Values.st2workflowengine.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2workflowengine.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in st2workflowengine.extra_volumes" .volume | toYaml) $ | nindent 10 }}
@@ -869,11 +857,9 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
-        {{- end }}
         {{- if .Values.st2scheduler.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -889,14 +875,12 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
-        {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2scheduler.postStartScript }}
         - name: st2-post-start-script-vol
@@ -1123,11 +1107,9 @@ spec:
         volumeMounts:
         {{- include "st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "packs-volume-mounts" $ | nindent 8 }}
-        {{- if $.Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
-        {{- end }}
         {{- range $sensor.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in $sensor.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in $sensor.extra_volumes" .mount | toYaml) $ | nindent 10 }}
@@ -1147,14 +1129,12 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" $ }}
     {{- end }}
       volumes:
-        {{- if $.Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ $.Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
-        {{- end }}
         {{- include "st2-config-volume" $ | nindent 8 }}
         {{- include "packs-volumes" $ | nindent 8 }}
         {{- range $sensor.extra_volumes }}
@@ -1262,11 +1242,9 @@ spec:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
-        {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "pack-configs-volume-mount" . | nindent 8 }}
@@ -1288,14 +1266,12 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
-        {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         - name: st2-ssh-key-vol
           secret:
@@ -1534,11 +1510,9 @@ spec:
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
-        {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- include "pack-configs-volume-mount" . | nindent 8 }}
         {{- range .Values.st2client.extra_volumes }}
@@ -1561,14 +1535,12 @@ spec:
             memory: "5Mi"
             cpu: "5m"
       volumes:
-        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
-        {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -204,9 +204,11 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
+        {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "pack-configs-volume-mount" . | nindent 8 }}
@@ -226,12 +228,14 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         {{- include "packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
@@ -561,9 +565,11 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
+        {{- end }}
         {{- if .Values.st2rulesengine.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -580,12 +586,14 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
         {{- if .Values.st2rulesengine.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -772,9 +780,11 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
+        {{- end }}
         {{- range .Values.st2workflowengine.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2workflowengine.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in st2workflowengine.extra_volumes" .mount | toYaml) $ | nindent 10 }}
@@ -795,12 +805,14 @@ spec:
     {{- end }}
       volumes:
         {{- include "st2-config-volume" . | nindent 8 }}
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
         {{- range .Values.st2workflowengine.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2workflowengine.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in st2workflowengine.extra_volumes" .volume | toYaml) $ | nindent 10 }}
@@ -889,9 +901,11 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
+        {{- end }}
         {{- if .Values.st2scheduler.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -907,12 +921,14 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2scheduler.postStartScript }}
         - name: st2-post-start-script-vol
@@ -1145,9 +1161,11 @@ spec:
         volumeMounts:
         {{- include "st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "packs-volume-mounts" $ | nindent 8 }}
+        {{- if $.Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
+        {{- end }}
         {{- range $sensor.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in $sensor.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in $sensor.extra_volumes" .mount | toYaml) $ | nindent 10 }}
@@ -1167,12 +1185,14 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" $ }}
     {{- end }}
       volumes:
+        {{- if $.Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ $.Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
         {{- include "st2-config-volume" $ | nindent 8 }}
         {{- include "packs-volumes" $ | nindent 8 }}
         {{- range $sensor.extra_volumes }}
@@ -1283,9 +1303,11 @@ spec:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
+        {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "pack-configs-volume-mount" . | nindent 8 }}
@@ -1307,12 +1329,14 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         - name: st2-ssh-key-vol
           secret:
@@ -1557,9 +1581,11 @@ spec:
           mountPath: /root/.st2/
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
           readOnly: true
+        {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- include "pack-configs-volume-mount" . | nindent 8 }}
         {{- range .Values.st2client.extra_volumes }}
@@ -1582,12 +1608,14 @@ spec:
             memory: "5Mi"
             cpu: "5m"
       volumes:
+        {{- if .Values.st2.datastore_crypto_key }}
         - name: st2-encryption-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-datastore-crypto-key
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
         {{- include "st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -24,7 +24,7 @@ data:
 {{- $previous := lookup "v1" "Secret" .Release.Namespace $name }}
 {{- if and $previous (not .Values.st2.datastore_crypto_key) }}
   datastore_crypto_key: {{ $previous.data.datastore_crypto_key }}
-{{- elif .Values.st2.datastore_crypto_key }}
+{{- else if .Values.st2.datastore_crypto_key }}
   datastore_crypto_key: {{ .Values.st2.datastore_crypto_key | b64enc }}
 {{- else }}
   datastore_crypto_key: {{ tpl (.Values.default_datastore_crypto_key | toJson) . | b64enc }}

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -20,6 +20,10 @@ metadata:
 type: Opaque
 data:
   # Datastore key used to encrypt/decrypt record for the KV store
+{{- if kindOf .Values.st2.datastore_crypto_key | eq "string" }}
   datastore_crypto_key: {{ .Values.st2.datastore_crypto_key | b64enc }}
+{{- else }}
+  datastore_crypto_key: {{ tpl (.Values.st2.datastore_crypto_key | toJson) . | b64enc }}
+{{- end }}
 
 {{- end }}

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -27,6 +27,6 @@ data:
 {{- else if .Values.st2.datastore_crypto_key }}
   datastore_crypto_key: {{ .Values.st2.datastore_crypto_key | b64enc }}
 {{- else }}
-  datastore_crypto_key: {{ tpl (.Values.default_datastore_crypto_key | toJson) . | b64enc }}
+  datastore_crypto_key: {{ tpl (.Values.default_datastore_crypto_key | toRawJson) . | b64enc }}
 {{- end }}
 

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -22,10 +22,10 @@ type: Opaque
 data:
   # Datastore key used to encrypt/decrypt record for the KV store
 {{- $previous := lookup "v1" "Secret" .Release.Namespace $name }}
-{{- if and $previous (not .Values.st2.datastore_crypto_key) }}
-  datastore_crypto_key: {{ $previous.data.datastore_crypto_key }}
-{{- else if .Values.st2.datastore_crypto_key }}
+{{- if .Values.st2.datastore_crypto_key }}
   datastore_crypto_key: {{ .Values.st2.datastore_crypto_key | b64enc }}
+{{- else if $previous }}
+  datastore_crypto_key: {{ $previous.data.datastore_crypto_key }}
 {{- else }}
   datastore_crypto_key: {{ tpl (.Files.Get "conf/datastore_crypto_key.yaml") . | fromYaml | toRawJson | b64enc }}
 {{- end }}

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -2,7 +2,7 @@
 {{- $deprecated_crypto_key := (default (dict) (default (dict) .Values.secrets).st2).datastore_crypto_key }}
 {{- if $deprecated_crypto_key }}
 {{- fail "Please update your values! The datastore_crypto_key value moved from secrets.st2.* to st2.*" }}
-{{- else if ne "disable" .Values.st2.datastore_crypto_key }}
+{{- else if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
 ---
 apiVersion: v1
 kind: Secret

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -27,6 +27,7 @@ data:
 {{- else if .Values.st2.datastore_crypto_key }}
   datastore_crypto_key: {{ .Values.st2.datastore_crypto_key | b64enc }}
 {{- else }}
-  datastore_crypto_key: {{ tpl (.Values.default_datastore_crypto_key | toRawJson) . | b64enc }}
+  {{/* We template in Yaml to avoid excessive escaping of quotes in Json */}}
+  datastore_crypto_key: {{ tpl (.Values.default_datastore_crypto_key | toYaml) . | fromYaml | toRawJson | b64enc }}
 {{- end }}
 

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -2,7 +2,7 @@
 {{- $deprecated_crypto_key := (default (dict) (default (dict) .Values.secrets).st2).datastore_crypto_key }}
 {{- if $deprecated_crypto_key }}
 {{- fail "Please update your values! The datastore_crypto_key value moved from secrets.st2.* to st2.*" }}
-{{- end }}
+{{- else if ne "disable" .Values.st2.datastore_crypto_key }}
 ---
 apiVersion: v1
 kind: Secret
@@ -30,3 +30,4 @@ data:
   datastore_crypto_key: {{ tpl (.Files.Get "conf/datastore_crypto_key.yaml") . | fromYaml | toRawJson | b64enc }}
 {{- end }}
 
+{{- end }}

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -2,12 +2,13 @@
 {{- $deprecated_crypto_key := (default (dict) (default (dict) .Values.secrets).st2).datastore_crypto_key }}
 {{- if $deprecated_crypto_key }}
 {{- fail "Please update your values! The datastore_crypto_key value moved from secrets.st2.* to st2.*" }}
-{{- else if .Values.st2.datastore_crypto_key }}
+{{- end }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-st2-datastore-crypto-key
+  {{- $name := print .Release.Name "-st2-datastore-crypto-key" }}
+  name: {{ $name }}
   annotations:
     description: StackStorm crypto key used to encrypt/decrypt KV records
   labels:
@@ -20,10 +21,12 @@ metadata:
 type: Opaque
 data:
   # Datastore key used to encrypt/decrypt record for the KV store
-{{- if kindOf .Values.st2.datastore_crypto_key | eq "string" }}
+{{- $previous := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- if and $previous (not .Values.st2.datastore_crypto_key) }}
+  datastore_crypto_key: {{ $previous.data.datastore_crypto_key }}
+{{- elif .Values.st2.datastore_crypto_key }}
   datastore_crypto_key: {{ .Values.st2.datastore_crypto_key | b64enc }}
 {{- else }}
-  datastore_crypto_key: {{ tpl (.Values.st2.datastore_crypto_key | toJson) . | b64enc }}
+  datastore_crypto_key: {{ tpl (.Values.default_datastore_crypto_key | toJson) . | b64enc }}
 {{- end }}
 
-{{- end }}

--- a/templates/secrets_datastore_crypto_key.yaml
+++ b/templates/secrets_datastore_crypto_key.yaml
@@ -27,7 +27,6 @@ data:
 {{- else if .Values.st2.datastore_crypto_key }}
   datastore_crypto_key: {{ .Values.st2.datastore_crypto_key | b64enc }}
 {{- else }}
-  {{/* We template in Yaml to avoid excessive escaping of quotes in Json */}}
-  datastore_crypto_key: {{ tpl (.Values.default_datastore_crypto_key | toYaml) . | fromYaml | toRawJson | b64enc }}
+  datastore_crypto_key: {{ tpl (.Files.Get "conf/datastore_crypto_key.yaml") . | fromYaml | toRawJson | b64enc }}
 {{- end }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -49,7 +49,9 @@ st2:
   #password: Ch@ngeMe
   # ST2 crypto key for the  K/V datastore.
   # See https://docs.stackstorm.com/datastore.html#securing-secrets-admin-only for more info.
-  # Warning! Replace with your own generated key!
+  # If set, st2.datastore_crypto_key always overrides any existing datastore_crypto_key.
+  # If not set, the datastore_crypto_key is auto-generated on install and preserved across upgrades.
+  # Generating datastore_crypto_key uses default_datastore_crypto_key below.
   #datastore_crypto_key: >-
   #  {"hmacKey": {"hmacKeyString": "", "size": 256}, "size": 256, "aesKeyString": "", "mode": "CBC"}
   # SSH private key for the 'stanley' system user ('system_user.ssh_key_file' in st2.conf)
@@ -932,3 +934,16 @@ external-dns:
   aws:
     zoneType: "public"
   domainFilters: []
+
+## Do not change this.
+## It is used to generate st2.datastore_crypto_key on install if not defined above.
+default_datastore_crypto_key:
+  # 32 bytes = 256 bits / 8 bits/byte
+  # randBytes returns a base64 encoded string.
+  hmacKey:
+    # this formula is based on an st2-specific version of python's base64.urlsafe_b64encode.
+    hmacKeyString: "{{ randBytes 32 | replace '+' '-' | replace '_' '/' | replace '=' '' }}"
+    size: 256
+  aesKeyString: "{{ randBytes 32 | replace '+' '-' | replace '_' '/' | replace '=' '' }}"
+  mode: CBC
+  size: 256

--- a/values.yaml
+++ b/values.yaml
@@ -942,8 +942,8 @@ default_datastore_crypto_key:
   # randBytes returns a base64 encoded string.
   hmacKey:
     # this formula is based on an st2-specific version of python's base64.urlsafe_b64encode.
-    hmacKeyString: "{{ randBytes 32 | replace '+' '-' | replace '_' '/' | replace '=' '' }}"
+    hmacKeyString: '{{ randBytes 32 | replace "+" "-" | replace "_" "/" | replace "=" "" }}'
     size: 256
-  aesKeyString: "{{ randBytes 32 | replace '+' '-' | replace '_' '/' | replace '=' '' }}"
+  aesKeyString: '{{ randBytes 32 | replace "+" "-" | replace "_" "/" | replace "=" "" }}'
   mode: CBC
   size: 256

--- a/values.yaml
+++ b/values.yaml
@@ -51,7 +51,6 @@ st2:
   # See https://docs.stackstorm.com/datastore.html#securing-secrets-admin-only for more info.
   # If set, st2.datastore_crypto_key always overrides any existing datastore_crypto_key.
   # If not set, the datastore_crypto_key is auto-generated on install and preserved across upgrades.
-  # Generating datastore_crypto_key uses default_datastore_crypto_key below.
   #datastore_crypto_key: >-
   #  {"hmacKey": {"hmacKeyString": "", "size": 256}, "size": 256, "aesKeyString": "", "mode": "CBC"}
   # SSH private key for the 'stanley' system user ('system_user.ssh_key_file' in st2.conf)
@@ -934,16 +933,3 @@ external-dns:
   aws:
     zoneType: "public"
   domainFilters: []
-
-## Do not change this.
-## It is used to generate st2.datastore_crypto_key on install if not defined above.
-default_datastore_crypto_key:
-  # 32 bytes = 256 bits / 8 bits/byte
-  # randBytes returns a base64 encoded string.
-  hmacKey:
-    # this formula is based on an st2-specific version of python's base64.urlsafe_b64encode.
-    hmacKeyString: '{{ randBytes 32 | replace "+" "-" | replace "_" "/" | replace "=" "" }}'
-    size: 256
-  aesKeyString: '{{ randBytes 32 | replace "+" "-" | replace "_" "/" | replace "=" "" }}'
-  mode: CBC
-  size: 256

--- a/values.yaml
+++ b/values.yaml
@@ -51,6 +51,7 @@ st2:
   # See https://docs.stackstorm.com/datastore.html#securing-secrets-admin-only for more info.
   # If set, st2.datastore_crypto_key always overrides any existing datastore_crypto_key.
   # If not set, the datastore_crypto_key is auto-generated on install and preserved across upgrades.
+  # If you want to disable datastore encryption, set "datastore_crypto_key: disable".
   #datastore_crypto_key: >-
   #  {"hmacKey": {"hmacKeyString": "", "size": 256}, "size": 256, "aesKeyString": "", "mode": "CBC"}
   # SSH private key for the 'stanley' system user ('system_user.ssh_key_file' in st2.conf)


### PR DESCRIPTION
OK. I wasn't going to implement this, but I did it anyway.

Other installation methods can call `st2-generate-symmetric-crypto-key` on install
to generate the key. But we need to put it in a kubernetes secret, so that is too
late to use for a new installation. Instead, we can generate the crypto key with
helm primitives.

Closes: #225
