### PR TITLE
fix st2web.postStartScript indent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * New feature: Add `envFromSecrets` to `st2actionrunner`, `st2client`, `st2sensorcontainer`, and jobs. This is useful for adding custom secrets to the environment. This complements the `extra_volumes` feature (loading secrets as files) to facilitate loading secrets that are not easily injected via the filesystem. (#259) (by @cognifloyd)
 * New feature to include `nodeSelector`, `affinity` and `tolerations` to `st2client`, allowing more flexibility to pod positioning. (#263) (by @sandesvitor)
 * Template `~/.st2/config`. This allows customizing the settings used by the `st2client` and jobs pods for using the st2 apis. (#262) (by @cognifloyd)
+* Fix indent for lifecycle postStart hook of `st2web` pod. (#268) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -437,9 +437,9 @@ spec:
             subPath: st2web.config.js
         {{- end }}
         {{- if .Values.st2web.postStartScript }}
-        - name: st2-post-start-script-vol
-          mountPath: /post-start.sh
-          subPath: post-start.sh
+          - name: st2-post-start-script-vol
+            mountPath: /post-start.sh
+            subPath: post-start.sh
         lifecycle:
           postStart:
             exec:


### PR DESCRIPTION
The indent for `st2web-config-vol` and `st2-post-start-script-vol` were not aligned. If both are provided, the generated yaml will fail to parse.

So, this fixes the indent.