### PR TITLE
apply annotations to deployments and jobs, not just pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 * Template `~/.st2/config`. This allows customizing the settings used by the `st2client` and jobs pods for using the st2 apis. (#262) (by @cognifloyd)
 * Fix indent for lifecycle postStart hook of `st2web` pod. (#268) (by @cognifloyd)
 * Advanced Feature: Allow `st2web` to serve HTTPS when the ssl certs are provided via `st2web.extra_volumes`. To enable this, add `ST2WEB_HTTPS: "1"` to `st2web.env` in your values file. (#264) (by @cognifloyd)
+* Custom annotations now apply to deployments and jobs, not just pods. (#270) (by @cognifloyd)
 
 ## v0.70.0
 * New feature: Shared packs volumes `st2.packs.volumes`. Allow using cluster-specific persistent volumes to store packs, virtualenvs, and (optionally) configs. This enables using `st2 pack install`. It even works with `st2packs` images in `st2.packs.images`. (#199) (by @cognifloyd)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -20,6 +20,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2auth.annotations }}
+  annotations: {{- toYaml .Values.st2auth.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -141,6 +144,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2api.annotations }}
+  annotations: {{- toYaml .Values.st2api.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -268,6 +274,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2stream.annotations }}
+  annotations: {{- toYaml .Values.st2stream.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -367,6 +376,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2web.annotations }}
+  annotations: {{- toYaml .Values.st2web.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -501,6 +513,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2rulesengine.annotations }}
+  annotations: {{- toYaml .Values.st2rulesengine.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -612,6 +627,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2timersengine.annotations }}
+  annotations: {{- toYaml .Values.st2timersengine.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -710,6 +728,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2workflowengine.annotations }}
+  annotations: {{- toYaml .Values.st2workflowengine.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -829,6 +850,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2scheduler.annotations }}
+  annotations: {{- toYaml .Values.st2scheduler.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -939,6 +963,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2notifier.annotations }}
+  annotations: {{- toYaml .Values.st2notifier.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -1045,6 +1072,9 @@ metadata:
     chart: {{ $.Chart.Name }}-{{ $.Chart.Version }}
     release: {{ $.Release.Name }}
     heritage: {{ $.Release.Service }}
+  {{- if $sensor.annotations }}
+  annotations: {{- toYaml $sensor.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -1203,6 +1233,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2actionrunner.annotations }}
+  annotations: {{- toYaml .Values.st2actionrunner.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -1352,6 +1385,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2garbagecollector.annotations }}
+  annotations: {{- toYaml .Values.st2garbagecollector.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -1449,6 +1485,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2client.annotations }}
+  annotations: {{- toYaml .Values.st2client.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:
@@ -1632,6 +1671,9 @@ metadata:
     chart: {{ .Chart.Name }}-{{ .Chart.Version }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- if .Values.st2chatops.annotations }}
+  annotations: {{- toYaml .Values.st2chatops.annotations | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -15,6 +15,9 @@ metadata:
     helm.sh/hook: post-install, post-upgrade, post-rollback
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "5"
+  {{- if .Values.jobs.annotations }}
+    {{- toYaml .Values.jobs.annotations | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:
@@ -114,6 +117,9 @@ metadata:
     helm.sh/hook: post-install, post-upgrade, post-rollback
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "6"
+  {{- if .Values.jobs.annotations }}
+    {{- toYaml .Values.jobs.annotations | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:
@@ -241,6 +247,9 @@ metadata:
     helm.sh/hook: post-install, post-upgrade, post-rollback
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "6"
+  {{- if .Values.jobs.annotations }}
+    {{- toYaml .Values.jobs.annotations | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:
@@ -362,6 +371,9 @@ metadata:
     helm.sh/hook: post-install, post-upgrade, post-rollback
     helm.sh/hook-delete-policy: before-hook-creation
     helm.sh/hook-weight: "7"
+  {{- if .Values.jobs.annotations }}
+    {{- toYaml .Values.jobs.annotations | nindent 4 }}
+  {{- end }}
 spec:
   template:
     metadata:


### PR DESCRIPTION
Apply annotations (added to Pods in #195) to Deployments and Jobs.

I need to apply annotations to Deployments due to cluster policies that require annotations on Deployments and not just on Pods.
