### PR TITLE
Add securityContext and podSecurityContext values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## In Development
+* Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -100,6 +100,9 @@ Create the name of the stackstorm-ha service account to use
           echo 'Waiting for MongoDB Connection...'
           sleep 2;
       done
+  {{- with .Values.securityContext }}
+  securityContext: {{- toYaml . | nindent 8 }}
+  {{- end }}
 {{- end }}
 {{- end -}}
 
@@ -117,6 +120,9 @@ Create the name of the stackstorm-ha service account to use
           echo 'Waiting for RabbitMQ Connection...'
           sleep 2;
       done
+  {{- with .Values.securityContext }}
+  securityContext: {{- toYaml . | nindent 8 }}
+  {{- end }}
   {{- end }}
 {{- end -}}
 
@@ -203,6 +209,9 @@ Create the name of the stackstorm-ha service account to use
     - |
       /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
       /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+  {{- with .Values.securityContext }}
+  securityContext: {{- toYaml . | nindent 8 }}
+  {{- end }}
     {{- end }}
   {{- end }}
   {{- if or $.Values.st2.packs.images $.Values.st2.packs.volumes.enabled }}
@@ -221,6 +230,9 @@ Create the name of the stackstorm-ha service account to use
     - |
       /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
       /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
+  {{- with .Values.securityContext }}
+  securityContext: {{- toYaml . | nindent 8 }}
+  {{- end }}
   {{- end }}
   {{- if and $.Values.st2.packs.configs $.Values.st2.packs.volumes.enabled }}
 # Pack configs defined in helm values
@@ -237,6 +249,9 @@ Create the name of the stackstorm-ha service account to use
     - '-ec'
     - |
       /bin/cp -aR /opt/stackstorm/configs/. /opt/stackstorm/configs-shared
+  {{- with .Values.securityContext }}
+  securityContext: {{- toYaml . | nindent 8 }}
+  {{- end }}
   {{- end }}
 {{- end -}}
 

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -432,7 +432,7 @@ spec:
       - name: st2web
         image: '{{ template "imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
-        {{- with .Values.securityContext }}
+        {{- with default .Values.securityContext .Values.st2web.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
         {{- end }}
         ports:
@@ -515,7 +515,7 @@ spec:
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
-    {{- with .Values.podSecurityContext }}
+    {{- with default .Values.podSecurityContext .Values.st2client.podSecurityContext }}
       securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2web.nodeSelector }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -61,6 +61,9 @@ spec:
       - name: generate-htpasswd
         image: '{{ template "imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
         - secretRef:
             name: {{ .Release.Name }}-st2-auth
@@ -75,6 +78,9 @@ spec:
       - name: st2auth
         image: '{{ template "imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 9100
         # TODO: Add liveness/readiness probes (#3)
@@ -121,6 +127,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2auth.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -191,6 +200,9 @@ spec:
       - name: st2api
         image: '{{ template "imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 9101
         # TODO: Add liveness/readiness probes (#3)
@@ -251,6 +263,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2api.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -314,6 +329,9 @@ spec:
       - name: st2stream
         image: '{{ template "imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 9102
         # TODO: Add liveness/readiness probes (#3)
@@ -353,6 +371,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2stream.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -411,6 +432,9 @@ spec:
       - name: st2web
         image: '{{ template "imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: {{ eq (get .Values.st2web.env "ST2WEB_HTTPS" | toString) "1" | ternary 443 80 }}
         # Probe to check if app is running. Failure will lead to a pod restart.
@@ -491,6 +515,9 @@ spec:
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.st2web.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -554,6 +581,9 @@ spec:
       - name: st2rulesengine
         image: '{{ template "imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -604,6 +634,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2rulesengine.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -668,6 +701,9 @@ spec:
       - name: st2timersengine
         image: '{{ template "imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -705,6 +741,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2timersengine.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -769,6 +808,9 @@ spec:
       - name: st2workflowengine
         image: '{{ template "imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -827,6 +869,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2workflowengine.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -890,6 +935,9 @@ spec:
       - name: st2scheduler
         image: '{{ template "imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -940,6 +988,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2scheduler.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -1003,6 +1054,9 @@ spec:
       - name: st2notifier
         image: '{{ template "imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -1040,6 +1094,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2notifier.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -1130,6 +1187,9 @@ spec:
       - name: {{ $name }}
         image: '{{ template "imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
+        {{- with default $.Values.securityContext $sensor.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         {{- with $sensor.readinessProbe }}
         # Probe to check if app is running. Failure will lead to a pod restart.
         readinessProbe:
@@ -1210,6 +1270,9 @@ spec:
     {{- with $.Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with default $.Values.podSecurityContext $sensor.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with $sensor.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -1286,6 +1349,9 @@ spec:
       - name: st2actionrunner
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -1363,6 +1429,9 @@ spec:
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with default .Values.podSecurityContext .Values.st2actionrunner.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.st2actionrunner.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -1425,6 +1494,9 @@ spec:
       - name: st2garbagecollector
         image: '{{ template "imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         # TODO: Add liveness/readiness probes (#3)
         #livenessProbe:
         #readinessProbe:
@@ -1462,6 +1534,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2garbagecollector.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -1532,6 +1607,9 @@ spec:
       - name: generate-st2client-config
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
@@ -1556,6 +1634,9 @@ spec:
       - name: st2client
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         env:
         - name: ST2CLIENT
           value: "1"
@@ -1648,6 +1729,15 @@ spec:
         - name: st2-post-start-script-vol
           configMap:
             name: {{ .Release.Name }}-st2client-post-start-script
+    {{- if .Values.dnsPolicy }}
+      dnsPolicy: {{ .Values.dnsPolicy }}
+    {{- end }}
+    {{- with .Values.dnsConfig }}
+      dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with default .Values.podSecurityContext .Values.st2client.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.st2client.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -1707,6 +1797,9 @@ spec:
       - name: st2chatops
         image: '{{ .Values.st2chatops.image.repository | default "stackstorm" }}/{{ .Values.st2chatops.image.name | default "st2chatops" }}:{{ tpl (.Values.st2chatops.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.st2chatops.image.pullPolicy | default .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
@@ -1764,6 +1857,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.st2chatops.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -45,6 +45,9 @@ spec:
       - name: st2-apply-rbac-definitions
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
           - st2-apply-rbac-definitions
           - --verbose
@@ -88,6 +91,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.jobs.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -147,6 +153,9 @@ spec:
       {{- include "init-containers-wait-for-db" . | nindent 6 }}
       - name: wait-for-api
         image: busybox:1.28
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
           - 'sh'
           - '-c'
@@ -158,6 +167,9 @@ spec:
       - name: generate-st2client-config
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
@@ -182,6 +194,9 @@ spec:
       - name: st2-apikey-load
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
           - st2
           - apikey
@@ -218,6 +233,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.jobs.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -279,6 +297,9 @@ spec:
       - name: generate-st2client-config
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         envFrom:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
@@ -303,6 +324,9 @@ spec:
       - name: st2-key-load
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
           - st2
           - key
@@ -342,6 +366,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.jobs.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
@@ -407,6 +434,9 @@ spec:
       - name: st2-register-content-custom-init
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         command: {{- toYaml $.Values.jobs.preRegisterContentCommand | nindent 8 }}
         volumeMounts:
         {{- include "st2-config-volume-mounts" . | nindent 8 }}
@@ -423,6 +453,9 @@ spec:
       - name: st2-register-content
         image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- with .Values.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+        {{- end }}
         command:
           - st2-register-content
           - --config-file=/etc/st2/st2.conf
@@ -456,6 +489,9 @@ spec:
     {{- end }}
     {{- with .Values.dnsConfig }}
       dnsConfig: {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.podSecurityContext }}
+      securityContext: {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.jobs.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}

--- a/values.yaml
+++ b/values.yaml
@@ -234,6 +234,13 @@ st2:
       #    - "admin"
 
 ##
+## Default SecurityContext for pods and containers.
+## Overrides available for st2actionrunner, st2sensorcontainer, and st2client pods.
+##
+podSecurityContext: {}
+securityContext: {}
+
+##
 ## StackStorm HA Ingress
 ##
 ingress:
@@ -561,6 +568,9 @@ st2actionrunner:
   envFromSecrets: []
   serviceAccount:
     attach: false
+  # override the default .podSecurityContext or .securityContext here
+  podSecurityContext: {}
+  securityContext: {}
   # postStartScript is optional. It has the contents of a bash script.
   # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
   # The pod will not be marked as "running" until this script completes successfully.
@@ -621,6 +631,9 @@ st2sensorcontainer:
   envFromSecrets: []
   serviceAccount:
     attach: false
+  # override the default .podSecurityContext or .securityContext here
+  podSecurityContext: {}
+  securityContext: {}
   # postStartScript is optional. It has the contents of a bash script.
   # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
   # The pod will not be marked as "running" until this script completes successfully.
@@ -652,6 +665,9 @@ st2client:
   image: {}
     ## Note that Helm templating is supported in this block!
     #tag: "{{ .Values.image.tag }}"
+  # override the default .podSecurityContext or .securityContext here
+  podSecurityContext: {}
+  securityContext: {}
   # postStartScript is optional. It has the contents of a bash script.
   # k8s will run the script in the st2 container in parallel with the ENTRYPOINT.
   # The pod will not be marked as "running" until this script completes successfully.

--- a/values.yaml
+++ b/values.yaml
@@ -235,7 +235,7 @@ st2:
 
 ##
 ## Default SecurityContext for pods and containers.
-## Overrides available for st2actionrunner, st2sensorcontainer, and st2client pods.
+## Overrides available for st2web, st2actionrunner, st2sensorcontainer, and st2client pods.
 ##
 podSecurityContext: {}
 securityContext: {}
@@ -311,6 +311,9 @@ st2web:
   # ST2WEB_HTTPS: 1
   serviceAccount:
     attach: false
+  # override the default .podSecurityContext or .securityContext here
+  podSecurityContext: {}
+  securityContext: {}  # NB: nginx requires some capabilities, drop ALL will cause issues.
   # mount extra volumes on the st2web pod(s) (primarily useful for k8s-provisioned secrets)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []


### PR DESCRIPTION
In some clusters, a validation controller can prohibit creating pods that have not dropped capabilities, or require SELinux, AppArmor, or some other security feature. This exposes the Kubernetes SecurityContext feature so that it can be configured via helm values.

- make securityContext and podSecurityContext configurable
- add changelog entry
