### PR TITLE
Standardize helper comments and names (prefix all helper names with stackstorm-ha)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## In Development
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
+* Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -34,9 +34,9 @@ Generate '-' prefix only when the variable is defined
 Allow calling helpers from nested sub-chart
 https://stackoverflow.com/a/52024583/4533625
 https://github.com/helm/helm/issues/4535#issuecomment-477778391
-Usage: "{{ include "nested" (list . "mongodb" "mongodb.fullname") }}"
+Usage: "{{ include "stackstorm-ha.nested" (list . "mongodb" "mongodb.fullname") }}"
 */}}
-{{- define "nested" }}
+{{- define "stackstorm-ha.nested" }}
 {{- $dot := index . 0 }}
 {{- $subchart := index . 1 | splitList "." }}
 {{- $template := index . 2 }}
@@ -50,10 +50,10 @@ Usage: "{{ include "nested" (list . "mongodb" "mongodb.fullname") }}"
 {{/*
 Generate comma-separated list of nodes for MongoDB-HA connection string, based on number of replicas and service name
 */}}
-{{- define "mongodb-nodes" -}}
+{{- define "stackstorm-ha.mongodb-nodes" -}}
 {{- $replicas := (int (index .Values "mongodb" "replicaCount")) }}
 {{- $architecture := (index .Values "mongodb" "architecture" ) }}
-{{- $mongo_fullname := include "nested" (list $ "mongodb" "mongodb.fullname") }}
+{{- $mongo_fullname := include "stackstorm-ha.nested" (list $ "mongodb" "mongodb.fullname") }}
 {{- range $index0 := until $replicas -}}
   {{- $index1 := $index0 | add1 -}}
   {{- if eq $architecture "replicaset" }}
@@ -67,7 +67,7 @@ Generate comma-separated list of nodes for MongoDB-HA connection string, based o
 {{/*
 Generate list of nodes for Redis with Sentinel connection string, based on number of replicas and service name
 */}}
-{{- define "redis-nodes" -}}
+{{- define "stackstorm-ha.redis-nodes" -}}
 {{- if not .Values.redis.sentinel.enabled }}
 {{- fail "value for redis.sentinel.enabled MUST be true" }}
 {{- end }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -86,7 +86,7 @@ Generate list of nodes for Redis with Sentinel connection string, based on numbe
 {{/*
 Reduce duplication of the st2.*.conf volume details
 */}}
-{{- define "st2-config-volume-mounts" -}}
+{{- define "stackstorm-ha.st2-config-volume-mounts" -}}
 - name: st2-config-vol
   mountPath: /etc/st2/st2.docker.conf
   subPath: st2.docker.conf
@@ -94,7 +94,7 @@ Reduce duplication of the st2.*.conf volume details
   mountPath: /etc/st2/st2.user.conf
   subPath: st2.user.conf
 {{- end -}}
-{{- define "st2-config-volume" -}}
+{{- define "stackstorm-ha.st2-config-volume" -}}
 - name: st2-config-vol
   configMap:
     name: {{ $.Release.Name }}-st2-config

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -26,7 +26,7 @@ Create the name of the stackstorm-ha service account to use
 {{/*
 Generate '-' prefix only when the variable is defined
 */}}
-{{- define "hyphenPrefix" -}}
+{{- define "stackstorm-ha.hyphenPrefix" -}}
 {{ if . }}-{{ . }}{{end}}
 {{- end -}}
 

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -100,7 +100,7 @@ Reduce duplication of the st2.*.conf volume details
     name: {{ $.Release.Name }}-st2-config
 {{- end -}}
 
-{{- define "init-containers-wait-for-db" -}}
+{{- define "stackstorm-ha.init-containers-wait-for-db" -}}
 {{- if index .Values "mongodb" "enabled" }}
 {{- $mongodb_port := (int (index .Values "mongodb" "service" "port")) }}
 - name: wait-for-db
@@ -120,7 +120,7 @@ Reduce duplication of the st2.*.conf volume details
 {{- end }}
 {{- end -}}
 
-{{- define "init-containers-wait-for-mq" -}}
+{{- define "stackstorm-ha.init-containers-wait-for-mq" -}}
   {{- if index .Values "rabbitmq" "enabled" }}
     {{- $rabbitmq_port := (int (index .Values "rabbitmq" "service" "port")) }}
 - name: wait-for-queue

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -143,7 +143,7 @@ Reduce duplication of the st2.*.conf volume details
 {{/*
 consolidate pack-configs-volumes definitions
 */}}
-{{- define "pack-configs-volume" -}}
+{{- define "stackstorm-ha.pack-configs-volume" -}}
   {{- if and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs }}
 - name: st2-pack-configs-vol
   {{- toYaml .Values.st2.packs.volumes.configs | nindent 2 }}
@@ -158,7 +158,7 @@ consolidate pack-configs-volumes definitions
     name: {{ .Release.Name }}-st2-pack-configs
   {{- end }}
 {{- end -}}
-{{- define "pack-configs-volume-mount" -}}
+{{- define "stackstorm-ha.pack-configs-volume-mount" -}}
 - name: st2-pack-configs-vol
   mountPath: /opt/stackstorm/configs/
   {{- if and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs .Values.st2.packs.configs }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -214,7 +214,7 @@ define this here as well to simplify comparison with packs-volume-mounts
 For custom st2packs-initContainers reduce duplicity by defining them here once
 Merge packs and virtualenvs from st2 with those from st2packs images
 */}}
-{{- define "packs-initContainers" -}}
+{{- define "stackstorm-ha.packs-initContainers" -}}
   {{- if $.Values.st2.packs.images }}
     {{- range $.Values.st2.packs.images }}
 - name: 'st2-custom-pack-{{ printf "%s-%s-%s" .repository .name .tag | sha1sum }}'

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -170,7 +170,7 @@ consolidate pack-configs-volumes definitions
 {{/*
 For custom st2packs-Container reduce duplicity by defining it here once
 */}}
-{{- define "packs-volumes" -}}
+{{- define "stackstorm-ha.packs-volumes" -}}
   {{- if .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
   {{- toYaml .Values.st2.packs.volumes.packs | nindent 2 }}
@@ -183,7 +183,7 @@ For custom st2packs-Container reduce duplicity by defining it here once
   emptyDir: {}
   {{- end }}
 {{- end -}}
-{{- define "packs-volume-mounts" -}}
+{{- define "stackstorm-ha.packs-volume-mounts" -}}
   {{- if .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
   mountPath: /opt/stackstorm/packs
@@ -201,7 +201,7 @@ For custom st2packs-Container reduce duplicity by defining it here once
 {{/*
 define this here as well to simplify comparison with packs-volume-mounts
 */}}
-{{- define "packs-volume-mounts-for-register-job" -}}
+{{- define "stackstorm-ha.packs-volume-mounts-for-register-job" -}}
   {{- if or .Values.st2.packs.images .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
   mountPath: /opt/stackstorm/packs

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -1,9 +1,13 @@
-# Expand the name of the chart.
+{{/*
+Expand the name of the chart.
+*/}}
 {{- define "stackstorm-ha.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-# Generate Docker image repository: Public Docker Hub 'stackstorm' for FOSS version
+{{/*
+Generate Docker image repository: Public Docker Hub 'stackstorm' for FOSS version
+*/}}
 {{- define "imageRepository" -}}
 {{- if .Values.image.repository -}}
 {{ .Values.image.repository }}
@@ -19,15 +23,19 @@ Create the name of the stackstorm-ha service account to use
 {{- default .Chart.Name .Values.serviceAccount.serviceAccountName -}}
 {{- end -}}
 
-# Generate '-' prefix only when the variable is defined
+{{/*
+Generate '-' prefix only when the variable is defined
+*/}}
 {{- define "hyphenPrefix" -}}
 {{ if . }}-{{ . }}{{end}}
 {{- end -}}
 
-# Allow calling helpers from nested sub-chart
-# https://stackoverflow.com/a/52024583/4533625
-# https://github.com/helm/helm/issues/4535#issuecomment-477778391
-# Usage: "{{ include "nested" (list . "mongodb" "mongodb.fullname") }}"
+{{/*
+Allow calling helpers from nested sub-chart
+https://stackoverflow.com/a/52024583/4533625
+https://github.com/helm/helm/issues/4535#issuecomment-477778391
+Usage: "{{ include "nested" (list . "mongodb" "mongodb.fullname") }}"
+*/}}
 {{- define "nested" }}
 {{- $dot := index . 0 }}
 {{- $subchart := index . 1 | splitList "." }}
@@ -39,7 +47,9 @@ Create the name of the stackstorm-ha service account to use
 {{- include $template (dict "Chart" (dict "Name" (last $subchart)) "Values" $values "Release" $dot.Release "Capabilities" $dot.Capabilities) }}
 {{- end }}
 
-# Generate comma-separated list of nodes for MongoDB-HA connection string, based on number of replicas and service name
+{{/*
+Generate comma-separated list of nodes for MongoDB-HA connection string, based on number of replicas and service name
+*/}}
 {{- define "mongodb-nodes" -}}
 {{- $replicas := (int (index .Values "mongodb" "replicaCount")) }}
 {{- $architecture := (index .Values "mongodb" "architecture" ) }}
@@ -54,7 +64,9 @@ Create the name of the stackstorm-ha service account to use
 {{- end -}}
 {{- end -}}
 
-# Generate list of nodes for Redis with Sentinel connection string, based on number of replicas and service name
+{{/*
+Generate list of nodes for Redis with Sentinel connection string, based on number of replicas and service name
+*/}}
 {{- define "redis-nodes" -}}
 {{- if not .Values.redis.sentinel.enabled }}
 {{- fail "value for redis.sentinel.enabled MUST be true" }}
@@ -71,7 +83,9 @@ Create the name of the stackstorm-ha service account to use
 {{- end -}}
 {{- end -}}
 
-# Reduce duplication of the st2.*.conf volume details
+{{/*
+Reduce duplication of the st2.*.conf volume details
+*/}}
 {{- define "st2-config-volume-mounts" -}}
 - name: st2-config-vol
   mountPath: /etc/st2/st2.docker.conf
@@ -126,7 +140,9 @@ Create the name of the stackstorm-ha service account to use
   {{- end }}
 {{- end -}}
 
-# consolidate pack-configs-volumes definitions
+{{/*
+consolidate pack-configs-volumes definitions
+*/}}
 {{- define "pack-configs-volume" -}}
   {{- if and .Values.st2.packs.volumes.enabled .Values.st2.packs.volumes.configs }}
 - name: st2-pack-configs-vol
@@ -151,7 +167,9 @@ Create the name of the stackstorm-ha service account to use
   {{- end }}
 {{- end -}}
 
-# For custom st2packs-Container reduce duplicity by defining it here once
+{{/*
+For custom st2packs-Container reduce duplicity by defining it here once
+*/}}
 {{- define "packs-volumes" -}}
   {{- if .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
@@ -180,7 +198,9 @@ Create the name of the stackstorm-ha service account to use
   readOnly: true
   {{- end }}
 {{- end -}}
-# define this here as well to simplify comparison with packs-volume-mounts
+{{/*
+define this here as well to simplify comparison with packs-volume-mounts
+*/}}
 {{- define "packs-volume-mounts-for-register-job" -}}
   {{- if or .Values.st2.packs.images .Values.st2.packs.volumes.enabled }}
 - name: st2-packs-vol
@@ -190,8 +210,10 @@ Create the name of the stackstorm-ha service account to use
   {{- end }}
 {{- end -}}
 
-# For custom st2packs-initContainers reduce duplicity by defining them here once
-# Merge packs and virtualenvs from st2 with those from st2packs images
+{{/*
+For custom st2packs-initContainers reduce duplicity by defining them here once
+Merge packs and virtualenvs from st2 with those from st2packs images
+*/}}
 {{- define "packs-initContainers" -}}
   {{- if $.Values.st2.packs.images }}
     {{- range $.Values.st2.packs.images }}
@@ -256,7 +278,9 @@ Create the name of the stackstorm-ha service account to use
 {{- end -}}
 
 
-# For custom st2packs-pullSecrets reduce duplicity by defining them here once
+{{/*
+For custom st2packs-pullSecrets reduce duplicity by defining them here once
+*/}}
 {{- define "packs-pullSecrets" -}}
   {{- range $.Values.st2.packs.images }}
     {{- if .pullSecret }}

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -8,7 +8,7 @@ Expand the name of the chart.
 {{/*
 Generate Docker image repository: Public Docker Hub 'stackstorm' for FOSS version
 */}}
-{{- define "imageRepository" -}}
+{{- define "stackstorm-ha.imageRepository" -}}
 {{- if .Values.image.repository -}}
 {{ .Values.image.repository }}
 {{- else -}}
@@ -239,7 +239,7 @@ Merge packs and virtualenvs from st2 with those from st2packs images
   {{- if or $.Values.st2.packs.images $.Values.st2.packs.volumes.enabled }}
 # System packs
 - name: st2-system-packs
-  image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
+  image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   volumeMounts:
   - name: st2-packs-vol
@@ -259,7 +259,7 @@ Merge packs and virtualenvs from st2 with those from st2packs images
   {{- if and $.Values.st2.packs.configs $.Values.st2.packs.volumes.enabled }}
 # Pack configs defined in helm values
 - name: st2-pack-configs-from-helm
-  image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
+  image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
   imagePullPolicy: {{ .Values.image.pullPolicy }}
   volumeMounts:
   - name: st2-pack-configs-vol

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -281,7 +281,7 @@ Merge packs and virtualenvs from st2 with those from st2packs images
 {{/*
 For custom st2packs-pullSecrets reduce duplicity by defining them here once
 */}}
-{{- define "packs-pullSecrets" -}}
+{{- define "stackstorm-ha.packs-pullSecrets" -}}
   {{- range $.Values.st2.packs.images }}
     {{- if .pullSecret }}
 - name: {{ .pullSecret }}

--- a/templates/configmaps_st2-conf.yaml
+++ b/templates/configmaps_st2-conf.yaml
@@ -24,7 +24,7 @@ data:
     ssh_key_file = {{ tpl .Values.st2.system_user.ssh_key_file . }}
     {{- if index .Values "redis" "enabled" }}
     [coordination]
-    url = redis://{{ template "redis-nodes" $ }}
+    url = redis://{{ template "stackstorm-ha.redis-nodes" $ }}
     {{- end }}
     {{- if index .Values "rabbitmq" "enabled" }}
     [messaging]
@@ -33,12 +33,12 @@ data:
     {{- if index .Values "mongodb" "enabled" }}
     [database]
     {{- if index .Values "mongodb" "auth" "enabled" }}
-    host = mongodb://{{ template "mongodb-nodes" $ }}/{{ required "mongodb.auth.database is required!" (index .Values "mongodb" "auth" "database") }}?authSource={{ required "mongodb.auth.database is required!" (index .Values "mongodb" "auth" "database") }}&replicaSet={{ index .Values "mongodb" "replicaSetName" }}
+    host = mongodb://{{ template "stackstorm-ha.mongodb-nodes" $ }}/{{ required "mongodb.auth.database is required!" (index .Values "mongodb" "auth" "database") }}?authSource={{ required "mongodb.auth.database is required!" (index .Values "mongodb" "auth" "database") }}&replicaSet={{ index .Values "mongodb" "replicaSetName" }}
     username = {{ required "mongodb.auth.username is required!" (index .Values "mongodb" "auth" "username") }}
     password = {{ required "mongodb.auth.password is required!" (index .Values "mongodb" "auth" "password") }}
     db_name = {{ required "mongodb.auth.database is required!" (index .Values "mongodb" "auth" "database") }}
     {{- else }}
-    host = mongodb://{{ template "mongodb-nodes" $ }}/?replicaSet={{ index .Values "mongodb" "replicaSetName" }}
+    host = mongodb://{{ template "stackstorm-ha.mongodb-nodes" $ }}/?replicaSet={{ index .Values "mongodb" "replicaSetName" }}
     {{- end }}
     port = {{ index .Values "mongodb" "service" "port" }}
     {{- end }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -194,7 +194,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
-        {{- include "packs-initContainers" . | nindent 6 }}
+        {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
       {{- end }}
       containers:
       - name: st2api
@@ -1181,7 +1181,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-db" $ | nindent 6 }}
       {{- include "stackstorm-ha.init-containers-wait-for-mq" $ | nindent 6 }}
       {{- if and $.Values.st2.packs.images (not $.Values.st2.packs.volumes.enabled) }}
-        {{- include "packs-initContainers" $ | nindent 6 }}
+        {{- include "stackstorm-ha.packs-initContainers" $ | nindent 6 }}
       {{- end }}
       containers:
       - name: {{ $name }}
@@ -1343,7 +1343,7 @@ spec:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
-        {{- include "packs-initContainers" . | nindent 6 }}
+        {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
       {{- end }}
       containers:
       - name: st2actionrunner
@@ -1601,7 +1601,7 @@ spec:
       {{- end }}
       initContainers:
       {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
-        {{- include "packs-initContainers" . | nindent 6 }}
+        {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -221,7 +221,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- include "packs-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- end }}
@@ -249,7 +249,7 @@ spec:
               path: datastore_key.json
         {{- end }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
-        {{- include "packs-volumes" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- end }}
@@ -1220,7 +1220,7 @@ spec:
         {{- end }}
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
-        {{- include "packs-volume-mounts" $ | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volume-mounts" $ | nindent 8 }}
         {{- if ne "disable" (default "" $.Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -1254,7 +1254,7 @@ spec:
               path: datastore_key.json
         {{- end }}
         {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
-        {{- include "packs-volumes" $ | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volumes" $ | nindent 8 }}
         {{- range $sensor.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in $sensor.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in $sensor.extra_volumes" .volume | toYaml) $ | nindent 10 }}
@@ -1374,7 +1374,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- include "packs-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- end }}
@@ -1412,7 +1412,7 @@ spec:
               path: {{ tpl .Values.st2.system_user.ssh_key_file . | base }}
               # 0400 file permission
               mode: 256
-        {{- include "packs-volumes" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- end }}
@@ -1667,7 +1667,7 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
-        {{- include "packs-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volume-mounts" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- range .Values.st2client.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}
@@ -1720,7 +1720,7 @@ spec:
               path: {{ tpl .Values.st2.system_user.ssh_key_file . | base }}
               # 0400 file permission
               mode: 256
-        {{- include "packs-volumes" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- range .Values.st2client.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -93,7 +93,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8  }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8  }}
         - name: htpasswd-vol
           mountPath: /etc/st2/htpasswd
           subPath: htpasswd
@@ -113,7 +113,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         - name: htpasswd-vol
           emptyDir:
             medium: Memory
@@ -215,7 +215,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -248,7 +248,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "pack-configs-volume" . | nindent 8 }}
@@ -344,7 +344,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2stream.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -360,7 +360,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2stream.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -594,7 +594,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -615,7 +615,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
@@ -714,7 +714,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2timersengine.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -730,7 +730,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2timersengine.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -821,7 +821,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -846,7 +846,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           secret:
@@ -948,7 +948,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
           mountPath: /etc/st2/keys
@@ -977,7 +977,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2scheduler.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1067,7 +1067,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2notifier.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -1083,7 +1083,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2notifier.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1219,7 +1219,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
-        {{- include "st2-config-volume-mounts" $ | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" $ | nindent 8 }}
         {{- include "packs-volume-mounts" $ | nindent 8 }}
         {{- if ne "disable" (default "" $.Values.st2.datastore_crypto_key) }}
         - name: st2-encryption-key-vol
@@ -1253,7 +1253,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        {{- include "st2-config-volume" $ | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" $ | nindent 8 }}
         {{- include "packs-volumes" $ | nindent 8 }}
         {{- range $sensor.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in $sensor.extra_volumes" .name }}
@@ -1366,7 +1366,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-ssh-key-vol
           mountPath: {{ tpl .Values.st2.system_user.ssh_key_file . | dir | dir }}/.ssh-key-vol/
         {{- if ne "disable" (default "" .Values.st2.datastore_crypto_key) }}
@@ -1403,7 +1403,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         - name: st2-ssh-key-vol
           secret:
             secretName: {{ .Release.Name }}-st2-ssh
@@ -1507,7 +1507,7 @@ spec:
         - configMapRef:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2garbagecollector.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -1523,7 +1523,7 @@ spec:
       serviceAccountName: {{ template "stackstorm-ha.serviceAccountName" . }}
     {{- end }}
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2garbagecollector.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1649,7 +1649,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol
           mountPath: /opt/stackstorm/rbac/roles/
@@ -1697,7 +1697,7 @@ spec:
             - key: datastore_crypto_key
               path: datastore_key.json
         {{- end }}
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- if .Values.st2.rbac.enabled }}
         - name: st2-rbac-roles-vol
           configMap:

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -223,7 +223,7 @@ spec:
         {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
-          {{- include "pack-configs-volume-mount" . | nindent 8 }}
+          {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- end }}
         {{- if .Values.st2api.postStartScript }}
         - name: st2-post-start-script-vol
@@ -251,7 +251,7 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
-          {{- include "pack-configs-volume" . | nindent 8 }}
+          {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- end }}
         {{- if .Values.st2api.postStartScript }}
         - name: st2-post-start-script-vol
@@ -1376,7 +1376,7 @@ spec:
         {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
-          {{- include "pack-configs-volume-mount" . | nindent 8 }}
+          {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- end }}
         {{- range .Values.st2actionrunner.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2actionrunner.extra_volumes" .name }}
@@ -1414,7 +1414,7 @@ spec:
               mode: 256
         {{- include "packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
-          {{- include "pack-configs-volume" . | nindent 8 }}
+          {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- end }}
         {{- range .Values.st2actionrunner.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2actionrunner.extra_volumes" .name }}
@@ -1668,7 +1668,7 @@ spec:
           readOnly: true
         {{- end }}
         {{- include "packs-volume-mounts" . | nindent 8 }}
-        {{- include "pack-configs-volume-mount" . | nindent 8 }}
+        {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- range .Values.st2client.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'mount' definition in st2client.extra_volumes" .mount | toYaml) $ | nindent 10 }}
@@ -1721,7 +1721,7 @@ spec:
               # 0400 file permission
               mode: 256
         {{- include "packs-volumes" . | nindent 8 }}
-        {{- include "pack-configs-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
         {{- range .Values.st2client.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in st2client.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in st2client.extra_volumes" .volume | toYaml) $ | nindent 10 }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -55,8 +55,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       - name: generate-htpasswd
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
@@ -191,8 +191,8 @@ spec:
         {{- include "packs-pullSecrets" . | nindent 6 }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
         {{- include "packs-initContainers" . | nindent 6 }}
       {{- end }}
@@ -323,8 +323,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2stream
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
@@ -575,8 +575,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2rulesengine
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
@@ -695,8 +695,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2timersengine
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
@@ -802,8 +802,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2workflowengine
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
@@ -929,8 +929,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2scheduler
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
@@ -1048,8 +1048,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2notifier
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
@@ -1178,8 +1178,8 @@ spec:
         {{- include "packs-pullSecrets" $ | nindent 6 }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" $ | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" $ | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" $ | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" $ | nindent 6 }}
       {{- if and $.Values.st2.packs.images (not $.Values.st2.packs.volumes.enabled) }}
         {{- include "packs-initContainers" $ | nindent 6 }}
       {{- end }}
@@ -1340,8 +1340,8 @@ spec:
         {{- include "packs-pullSecrets" . | nindent 6 }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       {{- if and .Values.st2.packs.images (not .Values.st2.packs.volumes.enabled) }}
         {{- include "packs-initContainers" . | nindent 6 }}
       {{- end }}
@@ -1488,8 +1488,8 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "init-containers-wait-for-mq" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2garbagecollector
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -59,7 +59,7 @@ spec:
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
       # Sidecar container for generating .htpasswd with st2 username & password pair and sharing produced file with the main st2auth container
       - name: generate-htpasswd
-        image: '{{ template "imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -76,7 +76,7 @@ spec:
           - printf "${ST2_AUTH_USERNAME}:$(openssl passwd -apr1 "${ST2_AUTH_PASSWORD}")\n" > /tmp/st2/htpasswd
       containers:
       - name: st2auth
-        image: '{{ template "imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2auth:{{ tpl (.Values.st2auth.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -198,7 +198,7 @@ spec:
       {{- end }}
       containers:
       - name: st2api
-        image: '{{ template "imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2api:{{ tpl (.Values.st2api.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -327,7 +327,7 @@ spec:
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2stream
-        image: '{{ template "imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2stream:{{ tpl (.Values.st2stream.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -430,7 +430,7 @@ spec:
       {{- end }}
       containers:
       - name: st2web
-        image: '{{ template "imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2web:{{ tpl (.Values.st2web.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2web.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -579,7 +579,7 @@ spec:
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2rulesengine
-        image: '{{ template "imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2rulesengine:{{ tpl (.Values.st2rulesengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -699,7 +699,7 @@ spec:
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2timersengine
-        image: '{{ template "imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2timersengine:{{ tpl (.Values.st2timersengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -806,7 +806,7 @@ spec:
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2workflowengine
-        image: '{{ template "imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2workflowengine:{{ tpl (.Values.st2workflowengine.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -933,7 +933,7 @@ spec:
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2scheduler
-        image: '{{ template "imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2scheduler:{{ tpl (.Values.st2scheduler.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1052,7 +1052,7 @@ spec:
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2notifier
-        image: '{{ template "imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2notifier:{{ tpl (.Values.st2notifier.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1185,7 +1185,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ $name }}
-        image: '{{ template "imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
+        image: '{{ template "stackstorm-ha.imageRepository" $ }}/st2sensorcontainer:{{ tpl ($sensor.image.tag | default $.Values.image.tag) $ }}'
         imagePullPolicy: {{ $.Values.image.pullPolicy }}
         {{- with default $.Values.securityContext $sensor.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1347,7 +1347,7 @@ spec:
       {{- end }}
       containers:
       - name: st2actionrunner
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2actionrunner.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1492,7 +1492,7 @@ spec:
       {{- include "init-containers-wait-for-mq" . | nindent 6 }}
       containers:
       - name: st2garbagecollector
-        image: '{{ template "imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2garbagecollector:{{ tpl (.Values.st2garbagecollector.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1605,7 +1605,7 @@ spec:
       {{- end }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -1632,7 +1632,7 @@ spec:
             EOT
       containers:
       - name: st2client
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.st2client.image.tag | default .Values.image.tag) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with default .Values.securityContext .Values.st2actionrunner.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -188,7 +188,7 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.images }}
-        {{- include "packs-pullSecrets" . | nindent 6 }}
+        {{- include "stackstorm-ha.packs-pullSecrets" . | nindent 6 }}
       {{- end }}
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
@@ -1175,7 +1175,7 @@ spec:
       - name: {{ $.Values.image.pullSecret }}
       {{- end }}
       {{- if $.Values.st2.packs.images }}
-        {{- include "packs-pullSecrets" $ | nindent 6 }}
+        {{- include "stackstorm-ha.packs-pullSecrets" $ | nindent 6 }}
       {{- end }}
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" $ | nindent 6 }}
@@ -1337,7 +1337,7 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if .Values.st2.packs.images }}
-        {{- include "packs-pullSecrets" . | nindent 6 }}
+        {{- include "stackstorm-ha.packs-pullSecrets" . | nindent 6 }}
       {{- end }}
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
@@ -1594,7 +1594,7 @@ spec:
     spec:
       imagePullSecrets:
       {{- if .Values.st2.packs.images }}
-        {{- include "packs-pullSecrets" . | nindent 6 }}
+        {{- include "stackstorm-ha.packs-pullSecrets" . | nindent 6 }}
       {{- end }}
       {{- if .Values.image.pullSecret }}
       - name: {{ .Values.image.pullSecret }}

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -1116,7 +1116,7 @@ spec:
       {{- $_ := set $sensor $key $val }}
     {{- end }}
   {{- end }}
-  {{- $name := print "st2sensorcontainer" (include "hyphenPrefix" $sensor.name) }}
+  {{- $name := print "st2sensorcontainer" (include "stackstorm-ha.hyphenPrefix" $sensor.name) }}
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -476,13 +476,13 @@ spec:
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "packs-volume-mounts-for-register-job" . | nindent 8 }}
-        {{- include "pack-configs-volume-mount" . | nindent 8 }}
+        {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "packs-volumes" . | nindent 8 }}
-        {{- include "pack-configs-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}
       dnsPolicy: {{ .Values.dnsPolicy }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -429,7 +429,7 @@ spec:
       {{- end }}
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
-      {{- include "packs-initContainers" . | nindent 6 }}
+      {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
       {{- if $.Values.jobs.preRegisterContentCommand }}
       - name: st2-register-content-custom-init
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -150,7 +150,7 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       - name: wait-for-api
         image: busybox:1.28
         {{- with .Values.securityContext }}
@@ -292,7 +292,7 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
@@ -428,7 +428,7 @@ spec:
         {{- include "packs-pullSecrets" . | nindent 6 }}
       {{- end }}
       initContainers:
-      {{- include "init-containers-wait-for-db" . | nindent 6 }}
+      {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       {{- include "packs-initContainers" . | nindent 6 }}
       {{- if $.Values.jobs.preRegisterContentCommand }}
       - name: st2-register-content-custom-init

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -425,7 +425,7 @@ spec:
       - name: {{ .Values.image.pullSecret }}
       {{- end }}
       {{- if $.Values.st2.packs.images -}}
-        {{- include "packs-pullSecrets" . | nindent 6 }}
+        {{- include "stackstorm-ha.packs-pullSecrets" . | nindent 6 }}
       {{- end }}
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -43,7 +43,7 @@ spec:
       {{- end }}
       containers:
       - name: st2-apply-rbac-definitions
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -165,7 +165,7 @@ spec:
             done
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -192,7 +192,7 @@ spec:
             EOT
       containers:
       - name: st2-apikey-load
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -295,7 +295,7 @@ spec:
       {{- include "init-containers-wait-for-db" . | nindent 6 }}
       # Sidecar container for generating st2client config with st2 username & password pair and sharing produced file with the main container
       - name: generate-st2client-config
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -322,7 +322,7 @@ spec:
             EOT
       containers:
       - name: st2-key-load
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -432,7 +432,7 @@ spec:
       {{- include "packs-initContainers" . | nindent 6 }}
       {{- if $.Values.jobs.preRegisterContentCommand }}
       - name: st2-register-content-custom-init
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}
@@ -451,7 +451,7 @@ spec:
       {{ end }}
       containers:
       - name: st2-register-content
-        image: '{{ template "imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
+        image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         {{- with .Values.securityContext }}
         securityContext: {{- toYaml . | nindent 10 }}

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -65,7 +65,7 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-rbac-roles-vol
           mountPath: /opt/stackstorm/rbac/roles/
         - name: st2-rbac-assignments-vol
@@ -75,7 +75,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         - name: st2-rbac-roles-vol
           configMap:
             name: {{ .Release.Name }}-st2-rbac-roles
@@ -344,7 +344,7 @@ spec:
             name: {{ . }}
         {{- end }}
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         - name: st2client-config-vol
           mountPath: /root/.st2/
         - name: st2-kv-vol
@@ -353,7 +353,7 @@ spec:
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         - name: st2client-config-vol
           emptyDir:
             medium: Memory
@@ -439,7 +439,7 @@ spec:
         {{- end }}
         command: {{- toYaml $.Values.jobs.preRegisterContentCommand | nindent 8 }}
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         - name: st2-pack-configs-vol
           mountPath: /opt/stackstorm/configs/
         {{- if .Values.st2.packs.images }}
@@ -474,13 +474,13 @@ spec:
         {{- end }}
         {{- end }}
         volumeMounts:
-        {{- include "st2-config-volume-mounts" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
         {{- include "packs-volume-mounts-for-register-job" . | nindent 8 }}
         {{- include "pack-configs-volume-mount" . | nindent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
-        {{- include "st2-config-volume" . | nindent 8 }}
+        {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "packs-volumes" . | nindent 8 }}
         {{- include "pack-configs-volume" . | nindent 8 }}
       restartPolicy: OnFailure

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -475,13 +475,13 @@ spec:
         {{- end }}
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
-        {{- include "packs-volume-mounts-for-register-job" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volume-mounts-for-register-job" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         # TODO: Find out default resource limits for this specific service (#5)
         #resources:
       volumes:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
-        {{- include "packs-volumes" . | nindent 8 }}
+        {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
       restartPolicy: OnFailure
     {{- if .Values.dnsPolicy }}

--- a/templates/tests/st2tests-pod.yaml
+++ b/templates/tests/st2tests-pod.yaml
@@ -28,7 +28,7 @@ spec:
   # Run the actual BATS tests
   containers:
   - name: st2tests
-    image: '{{ template "imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
+    image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ .Chart.AppVersion }}'
     imagePullPolicy: {{ .Values.image.pullPolicy }}
     envFrom:
     - configMapRef:


### PR DESCRIPTION
This standardizes the template helpers to follow Helm's documented "Best Practices":

https://helm.sh/docs/chart_best_practices/templates/#comments-yaml-comments-vs-template-comments
> Template comments should be used when documenting features of a template, such as explaining a defined template:
>
> ```
> {{- /*
> mychart.shortname provides a 6 char truncated version of the release name.
> */}}
> {{ define "mychart.shortname" -}}
> {{ .Release.Name | trunc 6 }}
> {{- end -}}
> ```

https://helm.sh/docs/chart_best_practices/templates/#names-of-defined-templates
> Defined templates (templates created inside a {{ define }} directive) are globally accessible. ...
> For that reason, all defined template names should be namespaced.
>
> Correct:
> ```
> {{- define "nginx.fullname" }}
> {{/* ... */}}
> {{ end -}}
> ```
>
> Incorrect:
> ```
> {{- define "fullname" -}}
> {{/* ... */}}
> {{ end -}}
> ```

- use helm-style comments in _helpers
- prefix imageRepository helper with stackstorm-ha
- prefix hyphenPrefix helper with stackstorm-ha
- prefix st2-config-volume* helpers with stackstorm-ha
- prefix init-containers-* helpers with stackstorm-ha
- prefix pack-configs-volume* helpers with stackstorm-ha
- prefix packs-volume* helpers with stackstorm-ha
- prefix packs-initContainers helper with stackstorm-ha
- prefix packs-pullSecrets helper with stackstorm-ha
- add changelog entry
