### PR TITLE
Extra volumes for logging conf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## In Development
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
+* New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/templates/deployments.yaml
+++ b/templates/deployments.yaml
@@ -98,6 +98,10 @@ spec:
           mountPath: /etc/st2/htpasswd
           subPath: htpasswd
           readOnly: true
+        {{- range .Values.st2auth.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2auth.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2auth.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2auth.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -117,6 +121,10 @@ spec:
         - name: htpasswd-vol
           emptyDir:
             medium: Memory
+        {{- range .Values.st2auth.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2auth.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2auth.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2auth.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -225,6 +233,10 @@ spec:
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "stackstorm-ha.pack-configs-volume-mount" . | nindent 8 }}
         {{- end }}
+        {{- range .Values.st2api.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2api.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2api.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2api.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -252,6 +264,10 @@ spec:
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- if .Values.st2.packs.volumes.enabled }}
           {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
+        {{- end }}
+        {{- range .Values.st2api.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2api.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2api.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.st2api.postStartScript }}
         - name: st2-post-start-script-vol
@@ -345,6 +361,10 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
+        {{- range .Values.st2stream.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2stream.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2stream.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2stream.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -361,6 +381,10 @@ spec:
     {{- end }}
       volumes:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
+        {{- range .Values.st2stream.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2stream.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2stream.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2stream.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -600,6 +624,10 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
+        {{- range .Values.st2rulesengine.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2rulesengine.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2rulesengine.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2rulesengine.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -623,6 +651,10 @@ spec:
             items:
             - key: datastore_crypto_key
               path: datastore_key.json
+        {{- end }}
+        {{- range .Values.st2rulesengine.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2rulesengine.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2rulesengine.extra_volumes" .volume | toYaml) $ | nindent 10 }}
         {{- end }}
         {{- if .Values.st2rulesengine.postStartScript }}
         - name: st2-post-start-script-vol
@@ -715,6 +747,10 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
+        {{- range .Values.st2timersengine.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2timersengine.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2timersengine.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2timersengine.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -731,6 +767,10 @@ spec:
     {{- end }}
       volumes:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
+        {{- range .Values.st2timersengine.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2timersengine.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2timersengine.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2timersengine.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -954,6 +994,10 @@ spec:
           mountPath: /etc/st2/keys
           readOnly: true
         {{- end }}
+        {{- range .Values.st2scheduler.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2scheduler.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2scheduler.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2scheduler.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -978,6 +1022,10 @@ spec:
               path: datastore_key.json
         {{- end }}
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
+        {{- range .Values.st2scheduler.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2scheduler.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2scheduler.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2scheduler.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1068,6 +1116,10 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
+        {{- range .Values.st2notifier.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2notifier.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2notifier.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2notifier.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -1084,6 +1136,10 @@ spec:
     {{- end }}
       volumes:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
+        {{- range .Values.st2notifier.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2notifier.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2notifier.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2notifier.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:
@@ -1508,6 +1564,10 @@ spec:
             name: {{ .Release.Name }}-st2-urls
         volumeMounts:
         {{- include "stackstorm-ha.st2-config-volume-mounts" . | nindent 8 }}
+        {{- range .Values.st2garbagecollector.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2garbagecollector.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'mount' definition in st2garbagecollector.extra_volumes" .mount | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2garbagecollector.postStartScript }}
         - name: st2-post-start-script-vol
           mountPath: /post-start.sh
@@ -1524,6 +1584,10 @@ spec:
     {{- end }}
       volumes:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
+        {{- range .Values.st2garbagecollector.extra_volumes }}
+        - name: {{ required "Each volume must have a 'name' in st2garbagecollector.extra_volumes" .name }}
+          {{- tpl (required "Each volume must have a 'volume' definition in st2garbagecollector.extra_volumes" .volume | toYaml) $ | nindent 10 }}
+        {{- end }}
         {{- if .Values.st2garbagecollector.postStartScript }}
         - name: st2-post-start-script-vol
           configMap:

--- a/values.yaml
+++ b/values.yaml
@@ -317,7 +317,7 @@ st2web:
   # mount extra volumes on the st2web pod(s) (primarily useful for k8s-provisioned secrets)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
-    # see examples under st2workflowengine.extra_volumes
+    # see examples under st2actionrunner.extra_volumes
   # User-defined st2web config with custom settings to replace default config.js
   # See https://github.com/StackStorm/st2web#connecting-to-st2-server for more info
   # config: |
@@ -327,6 +327,7 @@ st2web:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+
 # https://docs.stackstorm.com/reference/ha.html#st2auth
 # Multiple st2auth processes can be behind a load balancer in an active-active configuration.
 st2auth:
@@ -353,6 +354,11 @@ st2auth:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2auth pod(s) (primarily useful for custom logging conf)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
+
 # https://docs.stackstorm.com/reference/ha.html#st2api
 # Multiple st2api process can be behind a load balancer in an active-active configuration.
 st2api:
@@ -379,6 +385,11 @@ st2api:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2api pod(s) (primarily useful for custom logging conf)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
+
 # https://docs.stackstorm.com/reference/ha.html#st2stream
 # Multiple st2stream process can be behind a load balancer in an active-active configuration.
 st2stream:
@@ -405,6 +416,11 @@ st2stream:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2stream pod(s) (primarily useful for custom logging conf)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
+
 # https://docs.stackstorm.com/reference/ha.html#st2rulesengine
 # Multiple st2rulesengine processes can run in active-active with only connections to MongoDB and RabbitMQ. All these will share the TriggerInstance load and naturally pick up more work if one or more of the processes becomes unavailable.
 st2rulesengine:
@@ -431,6 +447,11 @@ st2rulesengine:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2rulesengine pod(s) (primarily useful for custom logging conf)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
+
 # https://docs.stackstorm.com/reference/ha.html#st2timersengine
 # Only single replica is created via K8s Deployment as timersengine can't work in active-active mode at the moment and it relies on K8s failover/reschedule capabilities to address cases of process failure.
 st2timersengine:
@@ -456,6 +477,11 @@ st2timersengine:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2timersengine pod (primarily useful for custom logging conf)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
+
 # https://docs.stackstorm.com/reference/ha.html#st2workflowengine
 # Multiple st2workflowengine processes can run in active-active mode and will share the load and pick up more work if one or more of the processes become available.
 st2workflowengine:
@@ -482,10 +508,11 @@ st2workflowengine:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
-  # mount extra volumes on the st2workflowengine pod(s) (primarily useful for k8s-provisioned secrets)
+  # mount extra volumes on the st2workflowengine pod(s) (primarily useful for custom logging conf)
   ## Note that Helm templating is supported in 'mount' and 'volume'
   extra_volumes: []
-    # see examples under st2workflowengine.extra_volumes
+    # see examples under st2actionrunner.extra_volumes
+
 # https://docs.stackstorm.com/reference/ha.html#st2scheduler
 # TODO: Description TBD
 st2scheduler:
@@ -512,6 +539,11 @@ st2scheduler:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2scheduler pod(s) (primarily useful for custom logging conf)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
+
 # https://docs.stackstorm.com/reference/ha.html#st2notifier
 # st2notifier runs in active-active mode and requires for that coordination backend like Redis or Zookeeper
 st2notifier:
@@ -538,6 +570,11 @@ st2notifier:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2notifier pod(s) (primarily useful for custom logging conf)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
+
 # https://docs.stackstorm.com/reference/ha.html#st2actionrunner
 # Multiple st2actionrunner processes can run in active-active with only connections to MongoDB and RabbitMQ. Work gets naturally
 # distributed across runners via RabbitMQ. Adding more st2actionrunner processes increases the ability of StackStorm to execute actions.
@@ -605,6 +642,15 @@ st2actionrunner:
     #   volume:
     #     configMap:
     #       name: "{{ .Release.Name }}-st2-ansible-config"
+    #
+    # An example that loads logging conf from a custom config map
+    # - name: custom-logging-conf
+    #   mount:
+    #     mountPath: /etc/st2/logging.docker.conf
+    #     subPath: logging.actionrunner.conf
+    #   volume:
+    #     configMap:
+    #       name: "{{ .Release.Name }}-st2-logging-conf"
 
 # https://docs.stackstorm.com/reference/ha.html#st2sensorcontainer
 # It is possible to run st2sensorcontainer(s) in one of these modes:
@@ -713,6 +759,10 @@ st2garbagecollector:
   # The pod will not be marked as "running" until this script completes successfully.
   # see: https://kubernetes.io/docs/concepts/containers/container-lifecycle-hooks/
   postStartScript: ""
+  # mount extra volumes on the st2garbagecollector pod(s) (primarily useful for custom logging conf)
+  ## Note that Helm templating is supported in 'mount' and 'volume'
+  extra_volumes: []
+    # see examples under st2actionrunner.extra_volumes
 
 ##
 ## StackStorm ChatOps (https://docs.stackstorm.com/chatops/index.html)


### PR DESCRIPTION
The logging conf files are baked into the docker image and provide only the minimal logging level. Generally this config can be updated by building a new docker image.

However, in some cases, it is helpful to be able to turn on/off debug logging to diagnose issues occurring only in particular clusters or environments. Sadly, there is no way to use env vars to configure that in StackStorm, so I need something more flexible to update logging conf files.

So, this expands the `extra_volumes` feature so that all of the python services can use it. Then, to update the logging conf file, just put the custom logging conf in a custom ConfigMap (managed outside of this chart), and then load it into the relevant deployments using `extra_volumes` values.

Resolves #269 