### PR TITLE
fix nil securityContext in packs-initContainers

### DIFF
--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -209,7 +209,7 @@ Create the name of the stackstorm-ha service account to use
     - |
       /bin/cp -aR /opt/stackstorm/packs/. /opt/stackstorm/packs-shared &&
       /bin/cp -aR /opt/stackstorm/virtualenvs/. /opt/stackstorm/virtualenvs-shared
-  {{- with .Values.securityContext }}
+  {{- with $.Values.securityContext }}
   securityContext: {{- toYaml . | nindent 8 }}
   {{- end }}
     {{- end }}


### PR DESCRIPTION
Fixes the following error on fe9b3a5ae93a1dc8002e39ce8a51686275dfba87 when using additional packs using Docker images:

```text
Error: template: stackstorm-ha/templates/jobs.yaml:432:10: executing "stackstorm-ha/templates/jobs.yaml" at <include "packs-initContainers" .>: error calling include: template: stackstorm-ha/templates/_helpers.tpl:213:18: executing "packs-initContainers" at <.Values.securityContext>: nil pointer evaluating interface {}.securityContext
```