### PR TITLE
Fixes reference to password value in st2 auth secret.

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -40,7 +40,7 @@ Ingress is enabled. You may access following endpoints:
 {{- end }}
 
 2. Get the password needed to login:
-kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.data.password}" secret {{ .Release.Name }}-st2-auth | base64 --decode
+kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.data.ST2_AUTH_PASSWORD}" secret {{ .Release.Name }}-st2-auth | base64 --decode
 
 3. Login with this username and the password retrieved above:
 username: {{ .Values.st2.username }}


### PR DESCRIPTION
The jsonpath for the password, [in the st2 auth secret](https://github.com/StackStorm/stackstorm-ha/blob/631b5175eeadfc79df2c5c6b048f03f2e9d22ccf/templates/secrets_st2auth.yaml#L29-L31), should be `.data.ST2_AUTH_PASSWORD`.