### PR TITLE
Basic Unit Test Infrastructure

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,31 @@
+---
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install pytest
+    - name: Test with pytest
+      run: |
+        pytest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -3,9 +3,12 @@ name: Python package
 
 on:
   push:
-    branches: [ master ]
+    branches:
+      - master
+      - unit-tests  # TODO: drop this
   pull_request:
-    branches: [ master ]
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,5 +1,5 @@
 ---
-name: Python package
+name: Unit Tests
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - master
 
 jobs:
-  build:
+  pytest:
 
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -37,10 +37,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install python dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install -r requirements-tests.txt
+    - name: Install chart dependencies
+      # build uses whatever is in Chart.lock
+      run: |
+        helm dependency build
     - name: Test with pytest
       run: |
         pytest

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - master
-      - unit-tests  # TODO: drop this
   pull_request:
     branches:
       - master

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -15,12 +15,24 @@ jobs:
 
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        python-version: ["3.10"]
+        # Relevant tools installed by default on ubuntu 20.04:
+        #   - helm 3.8.0
+        #   - jq 1.6
+        #   - kind 0.11.1
+        #   - kubectl 1.23.3
+        #   - minikube 1.25.1
+        #   - python 3.8.10
+        #   - yamllint 1.26.3
+        #   - yq 4.19.1
+        # see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+
+        python-version:
+          - "3.8"  # version available by default on the runner
 
     steps:
     - uses: actions/checkout@v2
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v2
       with:
@@ -28,7 +40,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install pytest
+        python -m pip install -r requirements-tests.txt
     - name: Test with pytest
       run: |
         pytest

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Apache Airflow
+Copyright 2016-2021 The Apache Software Foundation
+
+This product includes software developed at The Apache Software
+Foundation (http://www.apache.org/).
+=======================================================================

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,20 @@
+The chart in this repo is:
+Copyright 2020-2022 The StackStorm Authors.
+Copyright 2018-2019 Extreme Networks, Inc.
+
+Licensed under the Apache License, Version 2.0 (see the LICENSE file).
+
+Other included software noted below.
+
+=======================================================================
+
+tests/helm_template_generator.py is also under the Apache 2.0 license.
+It was extracted from https://github.com/apache/airflow
+(see the chart/tests/helm_template_generator.py file in that repo).
+Care was taken to include the git history to retain authorship info.
+
 Apache Airflow
 Copyright 2016-2021 The Apache Software Foundation
 
 This product includes software developed at The Apache Software
 Foundation (http://www.apache.org/).
-=======================================================================

--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,0 +1,6 @@
+jmespath
+jsonschema
+kubernetes
+pytest
+pyyaml
+requests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,72 @@
+import os
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from .helm_template_generator import render_chart
+
+# These fixtures provide some default values.
+# Tests can override them with parametrized values.
+
+
+@pytest.fixture
+def kubernetes_version() -> str:
+    """Return the default k8s version."""
+    return "1.22.0"
+
+
+@pytest.fixture
+def release_name() -> str:
+    """Return the default test release name."""
+    return "st2-ha"
+
+
+@pytest.fixture
+def namespace() -> str:
+    """Return the default test namespace."""
+    return "st2"
+
+
+@pytest.fixture
+def values() -> Dict[str, Any]:
+    """Return the default values."""
+    return {}
+
+
+@pytest.fixture
+def show_only() -> List[str]:
+    """Return the default list of resources to return from ``helm template``.
+
+    If an empty list, then all resources will be made available.
+    """
+    return []
+
+
+@pytest.fixture
+def chart_dir() -> str:
+    """Return the default chart_dir.
+
+    Tests might want to override this with a temporary directory
+    that copies a minimal set of the template files for a given test.
+    """
+    return os.path.dirname(os.path.dirname(__file__))
+
+
+@pytest.fixture
+def chart_resources(
+    kubernetes_version: str,
+    release_name: str,
+    namespace: str,
+    chart_dir: str,
+    values: Dict[str, Any],
+    show_only: List[str],
+) -> List[Dict[str, Any]]:
+    """Wrap the render_chart utility in a pytest.fixtrue."""
+    return render_chart(
+        name=release_name,
+        values=values,
+        show_only=show_only,
+        chart_dir=chart_dir,
+        kubernetes_version=kubernetes_version,
+        namespace=namespace,
+    )

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -19,6 +19,7 @@ import subprocess
 import sys
 from functools import lru_cache
 from tempfile import NamedTemporaryFile
+from typing import Any, Dict, Tuple
 
 import jmespath
 import jsonschema
@@ -79,6 +80,17 @@ def render_chart(name="RELEASE-NAME", values=None, show_only=None):
         for k8s_object in k8s_objects:
             validate_k8s_object(k8s_object)
         return k8s_objects
+
+
+def prepare_k8s_lookup_dict(k8s_objects) -> Dict[Tuple[str, str], Dict[str, Any]]:
+    """
+    Helper to create a lookup dict from k8s_objects.
+    The keys of the dict are the k8s object's kind and name
+    """
+    k8s_obj_by_key = {
+        (k8s_object["kind"], k8s_object["metadata"]["name"]): k8s_object for k8s_object in k8s_objects
+    }
+    return k8s_obj_by_key
 
 
 def render_k8s_object(obj, type_to_render):

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -75,7 +75,7 @@ def render_chart(name="RELEASE-NAME", values=None, show_only=None, validate_sche
             for i in show_only:
                 command.extend(["--show-only", i])
         templates = subprocess.check_output(command)
-        k8s_objects = yaml.load_all(templates)
+        k8s_objects = yaml.full_load_all(templates)
         k8s_objects = [k8s_object for k8s_object in k8s_objects if k8s_object]  # type: ignore
         if validate_schema:
             for k8s_object in k8s_objects:

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -61,7 +61,7 @@ def validate_k8s_object(instance):
     validate.validate(instance)
 
 
-def render_chart(name="RELEASE-NAME", values=None, show_only=None):
+def render_chart(name="RELEASE-NAME", values=None, show_only=None, validate_schema=True):
     """
     Function that renders a helm chart into dictionaries. For helm chart testing only
     """
@@ -77,8 +77,9 @@ def render_chart(name="RELEASE-NAME", values=None, show_only=None):
         templates = subprocess.check_output(command)
         k8s_objects = yaml.load_all(templates)
         k8s_objects = [k8s_object for k8s_object in k8s_objects if k8s_object]  # type: ignore
-        for k8s_object in k8s_objects:
-            validate_k8s_object(k8s_object)
+        if validate_schema:
+            for k8s_object in k8s_objects:
+                validate_k8s_object(k8s_object)
         return k8s_objects
 
 

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -29,7 +29,7 @@ from kubernetes.client.api_client import ApiClient
 
 api_client = ApiClient()
 
-BASE_URL_SPEC = "https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.12.9"
+BASE_URL_SPEC = "https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.0"
 
 
 @lru_cache(maxsize=None)

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -1,0 +1,51 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import subprocess
+import sys
+from tempfile import NamedTemporaryFile
+
+import yaml
+from kubernetes.client.api_client import ApiClient
+
+api_client = ApiClient()
+
+
+def render_chart(name="RELEASE-NAME", values=None, show_only=None):
+    """
+    Function that renders a helm chart into dictionaries. For helm chart testing only
+    """
+    values = values or {}
+    with NamedTemporaryFile() as tmp_file:
+        content = yaml.dump(values)
+        tmp_file.write(content.encode())
+        tmp_file.flush()
+        command = ["helm", "template", name, sys.path[0], '--values', tmp_file.name]
+        if show_only:
+            for i in show_only:
+                command.extend(["--show-only", i])
+        templates = subprocess.check_output(command)
+        k8s_objects = yaml.load_all(templates)
+        k8s_objects = [k8s_object for k8s_object in k8s_objects if k8s_object]  # type: ignore
+        return k8s_objects
+
+
+def render_k8s_object(obj, type_to_render):
+    """
+    Function that renders dictionaries into k8s objects. For helm chart testing only.
+    """
+    return api_client._ApiClient__deserialize_model(obj, type_to_render)  # pylint: disable=W0212

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -96,7 +96,7 @@ def render_chart(name="RELEASE-NAME", values=None, show_only=None):
         if show_only:
             for i in show_only:
                 command.extend(["--show-only", i])
-        templates = subprocess.check_output(command)
+        templates = subprocess.check_output(command, stderr=subprocess.PIPE)
         k8s_objects = yaml.full_load_all(templates)
         k8s_objects = [k8s_object for k8s_object in k8s_objects if k8s_object]  # type: ignore
         for k8s_object in k8s_objects:

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -30,7 +30,7 @@ from kubernetes.client.api_client import ApiClient
 
 api_client = ApiClient()
 
-BASE_URL_SPEC = "https://raw.githubusercontent.com/instrumenta/kubernetes-json-schema/master/v1.14.0"
+BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.15.0"
 
 crd_lookup = {
     'keda.sh/v1alpha1::ScaledObject': 'https://raw.githubusercontent.com/kedacore/keda/v2.0.0/config/crd/bases/keda.sh_scaledobjects.yaml',  # noqa: E501 # pylint: disable=line-too-long

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -83,16 +83,17 @@ def validate_k8s_object(instance):
     validate.validate(instance)
 
 
-def render_chart(name="RELEASE-NAME", values=None, show_only=None):
+def render_chart(name="RELEASE-NAME", values=None, show_only=None, chart_dir=None):
     """
     Function that renders a helm chart into dictionaries. For helm chart testing only
     """
     values = values or {}
+    chart_dir = chart_dir or sys.path[0]
     with NamedTemporaryFile() as tmp_file:
         content = yaml.dump(values)
         tmp_file.write(content.encode())
         tmp_file.flush()
-        command = ["helm", "template", name, sys.path[0], '--values', tmp_file.name]
+        command = ["helm", "template", name, chart_dir, '--values', tmp_file.name]
         if show_only:
             for i in show_only:
                 command.extend(["--show-only", i])

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -33,7 +33,7 @@ api_client = ApiClient()
 BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.15.0"
 
 crd_lookup = {
-    'keda.sh/v1alpha1::ScaledObject': 'https://raw.githubusercontent.com/kedacore/keda/v2.0.0/config/crd/bases/keda.sh_scaledobjects.yaml',  # noqa: E501 # pylint: disable=line-too-long
+    'keda.sh/v1alpha1::ScaledObject': 'https://raw.githubusercontent.com/kedacore/keda/v2.0.0/config/crd/bases/keda.sh_scaledobjects.yaml',  # noqa: E501
 }
 
 
@@ -120,4 +120,4 @@ def render_k8s_object(obj, type_to_render):
     """
     Function that renders dictionaries into k8s objects. For helm chart testing only.
     """
-    return api_client._ApiClient__deserialize_model(obj, type_to_render)  # pylint: disable=W0212
+    return api_client._ApiClient__deserialize_model(obj, type_to_render)

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -80,7 +80,7 @@ def create_validator(api_version, kind, kubernetes_version):
 
 
 def validate_k8s_object(instance, kubernetes_version):
-    # Skip PostgresSQL chart
+    # Skip PostgreSQL chart
     labels = jmespath.search("metadata.labels", instance)
     if "helm.sh/chart" in labels:
         chart = labels["helm.sh/chart"]

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -75,7 +75,12 @@ def create_validator(api_version, kind):
 
 def validate_k8s_object(instance):
     # Skip PostgresSQL chart
-    chart = jmespath.search("metadata.labels.chart", instance)
+    labels = jmespath.search("metadata.labels", instance)
+    if "helm.sh/chart" in labels:
+        chart = labels["helm.sh/chart"]
+    else:
+        chart = labels.get("chart")
+
     if chart and 'postgresql' in chart:
         return
 

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -105,12 +105,14 @@ def render_chart(
     show_only=None,
     chart_dir=None,
     kubernetes_version=DEFAULT_KUBERNETES_VERSION,
+    namespace=None,
 ):
     """
     Function that renders a helm chart into dictionaries. For helm chart testing only
     """
     values = values or {}
     chart_dir = chart_dir or sys.path[0]
+    namespace = namespace or "default"
     with NamedTemporaryFile() as tmp_file:
         content = yaml.dump(values)
         tmp_file.write(content.encode())
@@ -120,10 +122,12 @@ def render_chart(
             "template",
             name,
             chart_dir,
-            '--values',
+            "--values",
             tmp_file.name,
-            '--kube-version',
+            "--kube-version",
             kubernetes_version,
+            "--namespace",
+            namespace,
         ]
         if show_only:
             for i in show_only:

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -31,11 +31,16 @@ from kubernetes.client.api_client import ApiClient
 
 api_client = ApiClient()
 
-BASE_URL_SPEC = "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v"
 DEFAULT_KUBERNETES_VERSION = "1.22.0"
+BASE_URL_SPEC = (
+    f"https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/"
+    f"v{DEFAULT_KUBERNETES_VERSION}-standalone-strict"
+)
 
 crd_lookup = {
     'keda.sh/v1alpha1::ScaledObject': 'https://raw.githubusercontent.com/kedacore/keda/v2.0.0/config/crd/bases/keda.sh_scaledobjects.yaml',  # noqa: E501
+    # This object type was removed in k8s v1.22.0
+    'networking.k8s.io/v1beta1::Ingress': 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.21.0/ingress-networking-v1beta1.json',  # noqa: E501
 }
 
 
@@ -46,9 +51,9 @@ def get_schema_k8s(api_version, kind, kubernetes_version):
     if '/' in api_version:
         ext, _, api_version = api_version.partition("/")
         ext = ext.split(".")[0]
-        url = f'{BASE_URL_SPEC}{kubernetes_version}/{kind}-{ext}-{api_version}.json'
+        url = f'{BASE_URL_SPEC}/{kind}-{ext}-{api_version}.json'
     else:
-        url = f'{BASE_URL_SPEC}{kubernetes_version}/{kind}-{api_version}.json'
+        url = f'{BASE_URL_SPEC}/{kind}-{api_version}.json'
     request = requests.get(url)
     request.raise_for_status()
     schema = json.loads(

--- a/tests/helm_template_generator.py
+++ b/tests/helm_template_generator.py
@@ -38,9 +38,9 @@ BASE_URL_SPEC = (
 )
 
 crd_lookup = {
-    'keda.sh/v1alpha1::ScaledObject': 'https://raw.githubusercontent.com/kedacore/keda/v2.0.0/config/crd/bases/keda.sh_scaledobjects.yaml',  # noqa: E501
+    "keda.sh/v1alpha1::ScaledObject": "https://raw.githubusercontent.com/kedacore/keda/v2.0.0/config/crd/bases/keda.sh_scaledobjects.yaml",  # noqa: E501
     # This object type was removed in k8s v1.22.0
-    'networking.k8s.io/v1beta1::Ingress': 'https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.21.0/ingress-networking-v1beta1.json',  # noqa: E501
+    "networking.k8s.io/v1beta1::Ingress": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.21.0/ingress-networking-v1beta1.json",  # noqa: E501
 }
 
 
@@ -48,17 +48,18 @@ def get_schema_k8s(api_version, kind, kubernetes_version):
     api_version = api_version.lower()
     kind = kind.lower()
 
-    if '/' in api_version:
+    if "/" in api_version:
         ext, _, api_version = api_version.partition("/")
         ext = ext.split(".")[0]
-        url = f'{BASE_URL_SPEC}/{kind}-{ext}-{api_version}.json'
+        url = f"{BASE_URL_SPEC}/{kind}-{ext}-{api_version}.json"
     else:
-        url = f'{BASE_URL_SPEC}/{kind}-{api_version}.json'
+        url = f"{BASE_URL_SPEC}/{kind}-{api_version}.json"
     request = requests.get(url)
     request.raise_for_status()
     schema = json.loads(
         request.text.replace(
-            'kubernetesjsonschema.dev', 'raw.githubusercontent.com/yannh/kubernetes-json-schema/master'
+            "kubernetesjsonschema.dev",
+            "raw.githubusercontent.com/yannh/kubernetes-json-schema/master",
         )
     )
     return schema
@@ -69,7 +70,7 @@ def get_schema_crd(api_version, kind):
     if not url:
         return None
     response = requests.get(url)
-    yaml_schema = response.content.decode('utf-8')
+    yaml_schema = response.content.decode("utf-8")
     schema = yaml.safe_load(StringIO(yaml_schema))
     return schema
 
@@ -92,10 +93,12 @@ def validate_k8s_object(instance, kubernetes_version):
     else:
         chart = labels.get("chart")
 
-    if chart and 'postgresql' in chart:
+    if chart and "postgresql" in chart:
         return
 
-    validate = create_validator(instance.get("apiVersion"), instance.get("kind"), kubernetes_version)
+    validate = create_validator(
+        instance.get("apiVersion"), instance.get("kind"), kubernetes_version
+    )
     validate.validate(instance)
 
 
@@ -146,7 +149,8 @@ def prepare_k8s_lookup_dict(k8s_objects) -> Dict[Tuple[str, str], Dict[str, Any]
     The keys of the dict are the k8s object's kind and name
     """
     k8s_obj_by_key = {
-        (k8s_object["kind"], k8s_object["metadata"]["name"]): k8s_object for k8s_object in k8s_objects
+        (k8s_object["kind"], k8s_object["metadata"]["name"]): k8s_object
+        for k8s_object in k8s_objects
     }
     return k8s_obj_by_key
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -13,7 +13,9 @@ import pytest
         ),
     ],
 )
-def test_annotations(chart_resources: List[Dict[str, Any]], expected_annotations: Dict[str, str]) -> None:
+def test_annotations(
+    chart_resources: List[Dict[str, Any]], expected_annotations: Dict[str, str]
+) -> None:
     """Make sure that annotations are working"""
     # based on apache/airflow:chart/tests/tests_annotations::test_annotations_are_added
 

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict, List
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("values", "show_only", "expected_annotations"),
+    [
+        (
+            {"serviceAccount": {"serviceAccountAnnotations": {"foo": "bar"}}},
+            ["templates/service-account.yaml"],
+            {"foo": "bar"},
+        ),
+    ],
+)
+def test_annotations(chart_resources: List[Dict[str, Any]], expected_annotations: Dict[str, str]) -> None:
+    """Make sure that annotations are working"""
+    # based on apache/airflow:chart/tests/tests_annotations::test_annotations_are_added
+
+    # there's only one resource because we sepecified show_only.
+    assert len(chart_resources) == 1
+    service_account = chart_resources[0]
+
+    for name, value in expected_annotations.items():
+        assert name in service_account["metadata"]["annotations"]
+        assert value == service_account["metadata"]["annotations"][name]


### PR DESCRIPTION
This is part of #28.

Using `pytest`, this introduces a way to unit test the rendered templates.

For now, there is only one test showing how the infra works.
After this is merged, we can start adding tests for other template features.

### Why not helm-unittest?

These links explain why apache/airflow decided to abandon helm-unittest in favor of a pytest-based chart testing approach:

- https://github.com/helm-unittest/helm-unittest/issues/110
- https://github.com/apache/airflow/issues/11657

In short, I agree with their logic. StackStorm is a python-based solution. Helm offers some integration-style testing apparatus, but unit tests are rather difficult.
Different people have been maintaining helm-unittest, so there is no one canonical "upstream" repo for it. You have to search and figure out which one is the most maintained.
Plus, the YAML-based tests will be something else to learn and using python to test should allow for more expressive tests.

### Why pytest?

nosetest is not well maintained and is less well known. Eventually I want to replace nosetest with pytest in the main st2 repo. I've done quite a bit of preparatory work in that direction.
I do not want to introduce yet another unittest dependecy that will have to be migrated in the future.

I also strongly dislike the unittest-style `self.assert*` and I find debugging unittest tests very annoying.
Pytest-enhanced raw asserts are much more straightforward.

apache/airflow has an odd combo of unittest classes that they run with pytest. I avoid Unittest wherever possible, so I created pytest fixtures in this PR.

### tests/helm_template_generator.py

tests/helm_template_generator.py was developed by apache/airflow.
That project is Apache 2.0 licensed, so we can reuse it here.

To maintain authorship data, I imported the git history (using [this](https://www.pixelite.co.nz/article/extracting-file-folder-from-git-repository-with-full-git-history/)) for this file:
https://github.com/apache/airflow/blob/main/chart/tests/helm_template_generator.py
I also included the LICENSE file to make sure licensing is clear in our chart repo, and a copy of the NOTICE file from the apache/airflow repo.
