### PR TITLE
Add helm-unittest

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,45 @@
+---
+name: Unit Tests
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  helm-unittest:
+
+    runs-on: ubuntu-latest
+#    strategy:
+#      matrix:
+        # Relevant tools installed by default on ubuntu 20.04:
+        #   - helm 3.8.0
+        #   - jq 1.6
+        #   - kind 0.11.1
+        #   - kubectl 1.23.3
+        #   - minikube 1.25.1
+        #   - python 3.8.10
+        #   - yamllint 1.26.3
+        #   - yq 4.19.1
+        # see: https://github.com/actions/virtual-environments/blob/main/images/linux/Ubuntu2004-Readme.md
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Install helm-unittest
+      # We should periodically check to see if another fork has taken over maintenance,
+      # as the de-facto "best" fork has changed several times over the years.
+      run: |
+        helm plugin install https://github.com/quintush/helm-unittest
+
+    - name: Install chart dependencies
+      run: |
+        helm dependency update
+
+    - name: Run helm-unittest
+      # by default looks for tests/*_test.yaml
+      run: |
+        helm unittest --color --helm3 .

--- a/tests/dummy_test.yaml
+++ b/tests/dummy_test.yaml
@@ -1,0 +1,76 @@
+---
+suite: Dummy Tests
+templates:
+  - configmaps_st2-conf.yaml
+
+# this optionally overrides {{ .Release }}
+#release:
+#  name: my-release         # default: release-name
+#  namespace: my-namespace  # default: namespace
+#  revision: 1              # default: 0
+#  isUpgrade: true          # default: false
+
+# this optionally overrides {{ .Capabilities }}
+#capabilities:
+#  majorVersion: 1          # default from Helm
+#  minorVersion: 10         # default from Helm
+#  apiVersions:             # defaults to versionset used by k8s version
+#    - br.dev.local/v2
+
+# this optionally overrides {{ .Chart }}
+#chart:
+#  version: 1.0.0           # default from Chart.yaml
+#  appVersion: 1.0.0        # default from Chart.yaml
+  
+tests:
+
+  # name your test
+  - it: should pass
+
+  # define values
+    #values:  # like `helm install -f` or `helm install --values`
+    #  - ./values/staging.yaml
+    #set:  # like `helm install --set`
+    #  image.pullPolicy: Always
+    #  resources:
+    #    limits:
+    #      memory: 128Mi
+
+  # narrow the template selection if needed.
+    #template: deployment.yaml
+
+  # Select which document rendered by the template to use.
+  # This will be fiddly for us as we have multiple documents in many of our templates.
+  # So, we'll have to hard-code the order in our tests. Ick.
+    #documentIndex: 0  # default: -1 (ie assert on all documents)
+
+  # specify relevant overrides
+    #release:       # {{ .Release }}
+    #  name: my-release
+    #  namespace:
+    #  revision: 9
+    #  isUpgrade: true
+    #capabilities:  # {{ .Capabilities }}
+    #  majorVersion: 1
+    #  minorVersion: 12
+    #  apiVersions:
+    #    - custom.api/v1
+    #chart:         # {{ .Chart }}
+    #  version: 1.0.0
+    #  appVersion: 1.0.0
+
+  # the meat of the test
+    asserts:
+      #- equal:
+      #    path: metadata.name
+      #    value: my-deploy
+      #- equal:
+      #    path: metadata.name
+      #    value: your-service
+      #  not: true
+      #  template: web/service.yaml
+      #  documentIndex: 0
+
+    # our dummy test
+      - hasDocuments:
+          count: 1


### PR DESCRIPTION
Per #28 and https://github.com/StackStorm/stackstorm-ha/pull/283#pullrequestreview-885020923 unittests will use helm-unittest.

This adds a basic GHA workflow and a single dummy test. The dummy test is commented to document the various options in the test file.
