### PR TITLE
Add unit tests for a variety of chart aspects

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -42,4 +42,4 @@ jobs:
     - name: Run helm-unittest
       # by default looks for tests/*_test.yaml
       run: |
-        helm unittest --color --helm3 -f tests/unit/*_test.yaml .
+        helm unittest --color --helm3 -f 'tests/unit/*_test.yaml' .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
-* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, and affinity. (#284, #288)
+* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, and dnsConfig. (#284, #288)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
-* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, and pullPolicy. (#284, #288)
+* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, and Resources. (#284, #288)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
-* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, dnsConfig, ServiceAccount attach, and postStartScript. (#284, #288)
+* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, dnsConfig, ServiceAccount attach, postStartScript, and both sensor-modes. (#284, #288)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
-* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, and SecurityContext. (#284, #288)
+* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, and pullPolicy. (#284, #288)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
-* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, and dnsConfig. (#284, #288)
+* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, dnsConfig, and ServiceAccount attach. (#284, #288)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
-* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, dnsConfig, and ServiceAccount attach. (#284, #288)
+* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, dnsConfig, ServiceAccount attach, and postStartScript. (#284, #288)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
-* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for custom annotations. (#284)
+* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, and SecurityContext. (#284, #288)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Advanced Feature: Make securityContext (on Deployments/Jobs) and podSecurityContext (on Pods) configurable. This allows dropping all capabilities, for example. You can override the securityContext for `st2actionrunner`, `st2sensorcontainer`, and `st2client` if your actions or sensors need, for example, additional capabilites that the rest of StackStorm does not need. (#271) (by @cognifloyd)
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
-* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, and Resources. (#284, #288)
+* Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, and affinity. (#284, #288)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/tests/README.md
+++ b/tests/README.md
@@ -17,7 +17,7 @@ helm dependency update
 
 To run the tests manually from the chart's root dir:
 ```
-helm unittest --helm3 -f tests/unit/*_test.yaml .
+helm unittest --helm3 -f 'tests/unit/*_test.yaml' .
 ```
 
 > Note! If you need to add unit tests, file names should follow this pattern: `tests/unit/name_your_test.yaml`

--- a/tests/unit/custom_annotations_test.yaml
+++ b/tests/unit/custom_annotations_test.yaml
@@ -89,7 +89,7 @@ tests:
         annotations: *deployment_annotations
       st2sensorcontainer:
         annotations: *deployment_annotations
-      st2: { packs: { sensors: [] } }  # ensure only 1 sensor
+      st2: { packs: { sensors: [] } } # ensure only 1 sensor
       st2actionrunner:
         annotations: *deployment_annotations
       st2garbagecollector:

--- a/tests/unit/dns_test.yaml
+++ b/tests/unit/dns_test.yaml
@@ -17,10 +17,6 @@ templates:
   - secrets_st2auth.yaml
   - secrets_st2chatops.yaml
 
-# relevant values:
-#   dnsPolicy:
-#   dnsConfig:
-
 tests:
   - it: Deployments and Jobs default to no dnsPolicy or dnsConfig
     templates:

--- a/tests/unit/dns_test.yaml
+++ b/tests/unit/dns_test.yaml
@@ -1,0 +1,64 @@
+---
+suite: DNS
+templates:
+  # primary template files
+  - deployments.yaml
+  - jobs.yaml
+
+  # included templates must also be listed
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2-urls.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2apikeys.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+# relevant values:
+#   dnsPolicy:
+#   dnsConfig:
+
+tests:
+  - it: Deployments and Jobs default to no dnsPolicy or dnsConfig
+    templates:
+      - deployments.yaml
+      - jobs.yaml
+    set:
+      st2: 
+        packs: { sensors: [] } # ensure only 1 sensor
+        rbac: { enabled: true } # enable rbac job
+    asserts:
+      - isNull:
+          path: spec.template.spec.dnsPolicy
+      - isNull:
+          path: spec.template.spec.dnsConfig
+
+  - it: Deployments and Jobs accept custom dnsPolicy or dnsConfig
+    templates:
+      - deployments.yaml
+      - jobs.yaml
+    set:
+      dnsPolicy: &dnsPolicy ClusterFirstWithHostNet
+      dnsConfig: &dnsConfig
+        nameservers:
+          - 1.2.3.4
+        searches:
+          - ns1.svc.cluster-domain.example
+          - my.dns.search.suffix
+        options:
+          - name: ndots
+            value: "2"
+          - name: edns0
+      st2: 
+        packs: { sensors: [] } # ensure only 1 sensor
+        rbac: { enabled: true } # enable rbac job
+    asserts:
+      - equal:
+          path: spec.template.spec.dnsPolicy
+          value: *dnsPolicy
+      - equal:
+          path: spec.template.spec.dnsConfig
+          value: *dnsConfig

--- a/tests/unit/image_pull_test.yaml
+++ b/tests/unit/image_pull_test.yaml
@@ -1,0 +1,118 @@
+---
+suite: Image Pull
+templates:
+  # primary template files
+  - deployments.yaml
+  - jobs.yaml
+  - service-account.yaml
+
+  # included templates must also be listed
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2-urls.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2apikeys.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+# relevant values:
+#   imagePullPolicy
+#     image.pullPolicy
+#     serviceAccount.pullPolicy
+#     st2.packs.images[].pullPolicy
+#   imagePullSecreets
+#     image.pullSecret
+#     serviceAccount.pullSecret
+#     st2.packs.images[].pullSecret
+
+tests:
+  - it: Deployments and Jobs use default pullPolicy and pullSecret
+    templates:
+      - deployments.yaml
+        # st2auth, st2api,
+        # st2stream, st2web,
+        # st2rulesengine, st2timersengine,
+        # st2workflowengine, st2scheduler,
+        # st2notifier, (1) st2sensorcontainer,
+        # st2actionrunner, st2garbagecollector,
+        # st2client, st2chatops
+      - jobs.yaml
+        # job-st2-apply-rbac-defintions
+        # job-st2-apikey-load
+        # job-st2-key-load
+        # job-st2-register-content
+    set:
+      # image.pullPolicy defaults to IfNotPresent
+      # image.pullSecret defaults to None
+      serviceAccount:
+        create: true
+        # show that this does not affect pod specs
+        pullSecret: service-account-pull-secret
+      st2:
+        rbac: { enabled: true } # enable rbac job
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.imagePullSecrets
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+      # path can only select one element, not all initContainers (if present).
+      #- equal:
+      #    path: 'spec.template.spec.initContainers[].imagePullPolicy'
+      #    value: IfNotPresent
+
+  - it: Deployments and Jobs use custom pullPolicy and pullSecret
+    templates:
+      - deployments.yaml
+      - jobs.yaml
+    set:
+      image:
+        pullPolicy: Always
+        pullSecret: custom-pull-secret
+      serviceAccount:
+        create: true
+        # show that this does not affect pod specs
+        pullSecret: service-account-pull-secret
+      st2:
+        rbac: { enabled: true } # enable rbac job
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: custom-pull-secret
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: Always
+      # path can only select one element, not all initContainers (if present).
+      #- equal:
+      #    path: 'spec.template.spec.initContainers[].imagePullPolicy'
+      #    value: Always
+
+  - it: ServiceAccount has no imagePullSecret by default
+    template: service-account.yaml
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - isNull:
+          path: imagePullSecrets
+
+  - it: ServiceAccount accepts custom imagePullSecret
+    template: service-account.yaml
+    set:
+      serviceAccount:
+        create: true
+        # show that this does not affect pod specs
+        pullSecret: service-account-pull-secret
+    asserts:
+      - equal:
+          path: imagePullSecrets[0].name
+          value: service-account-pull-secret

--- a/tests/unit/labels_test.yaml
+++ b/tests/unit/labels_test.yaml
@@ -33,7 +33,7 @@ tests:
   - it: Deployments+Pods have requried labels
     template: deployments.yaml
     set:
-      st2: { packs: { sensors: [] } }  # ensure only 1 sensor
+      st2: { packs: { sensors: [] } } # ensure only 1 sensor
       st2chatops:
         enabled: true
     asserts:

--- a/tests/unit/labels_test.yaml
+++ b/tests/unit/labels_test.yaml
@@ -1,0 +1,234 @@
+---
+suite: Labels
+templates:
+  - deployments.yaml
+  - jobs.yaml
+  - services.yaml
+
+  - configmaps_packs.yaml
+  - configmaps_post-start-scripts.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2-urls.yaml
+  - configmaps_st2web.yaml
+
+  - secrets_datastore_crypto_key.yaml
+  - secrets_rabbit.yaml
+  - secrets_ssh.yaml
+  - secrets_st2apikeys.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+  - secrets_st2kv.yaml
+
+  - service-account.yaml
+
+  - ingress.yaml
+
+release:
+  name: some-release-name
+chart:
+  version: 1.0.999
+
+tests:
+  - it: Deployments+Pods have requried labels
+    template: deployments.yaml
+    set:
+      st2: { packs: { sensors: [] } }  # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 14
+          # st2auth, st2api,
+          # st2stream, st2web,
+          # st2rulesengine, st2timersengine,
+          # st2workflowengine, st2scheduler,
+          # st2notifier, (1) st2sensorcontainer,
+          # st2actionrunner, st2garbagecollector,
+          # st2client, st2chatops
+
+      # each of these should be the same, but there is no test for that:
+      #   metdata.labels.app
+      #   spec.selector.matchLabels.app
+      #   spec.template.metadata.labels.app
+      # So, we use isNotNull instead.
+      # see: https://github.com/quintush/helm-unittest/issues/122
+      - isNotNull: { path: metadata.labels.app }
+      - isNotNull: { path: spec.selector.matchLabels.app }
+      - isNotNull: { path: spec.template.metadata.labels.app }
+
+      - equal:
+          path: metadata.labels.release
+          value: some-release-name
+      - equal:
+          path: spec.selector.matchLabels.release
+          value: some-release-name
+      - equal:
+          path: spec.template.metadata.labels.release
+          value: some-release-name
+
+      - matchRegex:
+          path: metadata.labels.tier
+          pattern: ^(backend|frontend)$
+      - matchRegex:
+          path: spec.template.metadata.labels.tier
+          pattern: ^(backend|frontend)$
+
+      - equal:
+          path: metadata.labels.vendor
+          value: stackstorm
+      - equal:
+          path: spec.template.metadata.labels.vendor
+          value: stackstorm
+
+      - equal:
+          path: metadata.labels.chart
+          value: stackstorm-ha-1.0.999
+      - equal:
+          path: spec.template.metadata.labels.chart
+          value: stackstorm-ha-1.0.999
+
+      - equal:
+          path: metadata.labels.heritage
+          value: Helm
+      - equal:
+          path: spec.template.metadata.labels.heritage
+          value: Helm
+
+  - it: Jobs+Pods have requried labels
+    template: jobs.yaml
+    set:
+      st2:
+        rbac:
+          enabled: true # enable rbac job
+    asserts:
+      - hasDocuments:
+          count: 4
+          # job-st2-apply-rbac-defintions
+          # job-st2-apikey-load
+          # job-st2-key-load
+          # job-st2-register-content
+
+      # unlike deployments, jobs should not have selector.matchLabels
+
+      # like deployments each of these should be the same:
+      #   metdata.labels.app
+      #   spec.template.metadata.labels.app
+      - isNotNull: { path: metadata.labels.app }
+      - isNotNull: { path: spec.template.metadata.labels.app }
+
+      - equal:
+          path: metadata.labels.release
+          value: some-release-name
+      - equal:
+          path: spec.template.metadata.labels.release
+          value: some-release-name
+
+      - matchRegex:
+          path: metadata.labels.tier
+          pattern: ^(backend|frontend)$
+      - matchRegex:
+          path: spec.template.metadata.labels.tier
+          pattern: ^(backend|frontend)$
+
+      - equal:
+          path: metadata.labels.vendor
+          value: stackstorm
+      - equal:
+          path: spec.template.metadata.labels.vendor
+          value: stackstorm
+
+      - equal:
+          path: metadata.labels.chart
+          value: stackstorm-ha-1.0.999
+      - equal:
+          path: spec.template.metadata.labels.chart
+          value: stackstorm-ha-1.0.999
+
+      - equal:
+          path: metadata.labels.heritage
+          value: Helm
+      - equal:
+          path: spec.template.metadata.labels.heritage
+          value: Helm
+
+  - it: Services have required labels
+    template: services.yaml
+    set:
+      st2chatops:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 5
+          # st2auth, st2api, st2stream, st2web, st2chatops
+
+      - isNotNull: { path: metadata.labels.app }
+      - equal:
+          path: metadata.labels.release
+          value: some-release-name
+      - matchRegex:
+          path: metadata.labels.tier
+          pattern: ^(backend|frontend)$
+      - equal:
+          path: metadata.labels.vendor
+          value: stackstorm
+      - equal:
+          path: metadata.labels.chart
+          value: stackstorm-ha-1.0.999
+      - equal:
+          path: metadata.labels.heritage
+          value: Helm
+
+  - it: ServiceAccount has required labels
+    template: service-account.yaml
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - equal:
+          path: metadata.labels.app
+          value: stackstorm-ha
+      - equal:
+          path: metadata.labels.release
+          value: some-release-name
+      # ServiceAccount does not have tier or vendor
+      #- equal:
+      #    path: metadata.labels.tier
+      #    value: backend
+      #- equal:
+      #    path: metadata.labels.vendor
+      #    value: stackstorm
+      - equal:
+          path: metadata.labels.chart
+          value: stackstorm-ha-1.0.999
+      - equal:
+          path: metadata.labels.heritage
+          value: Helm
+
+  - it: st2web Ingress has required labels
+    template: ingress.yaml
+    set:
+      st2web:
+        service:
+          hostname: some-host-name
+      ingress:
+        enabled: true
+    assert:
+      - equal:
+          path: metadata.labels.app
+          value: ingress
+      - equal:
+          path: metadata.labels.release
+          value: some-release-name
+      - equal:
+          path: metadata.labels.tier
+          value: frontend
+      - equal:
+          path: metadata.labels.vendor
+          value: stackstorm
+      - equal:
+          path: metadata.labels.chart
+          value: stackstorm-ha-1.0.999
+      - equal:
+          path: metadata.labels.heritage
+          value: Helm

--- a/tests/unit/placement_test.yaml
+++ b/tests/unit/placement_test.yaml
@@ -1,0 +1,185 @@
+---
+suite: Placement (NodeSelector Tolerations and Affinity)
+templates:
+  # primary template files
+  - deployments.yaml
+  - jobs.yaml
+
+  # included templates must also be listed
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2-urls.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2apikeys.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+# nodeSelector & tolerations & affinity:
+#   st2web .nodeSelector, .tolerations, .affinity
+#   st2auth .nodeSelector, .tolerations, .affinity
+#   st2api .nodeSelector, .tolerations, .affinity
+#   st2stream .nodeSelector, .tolerations, .affinity
+#   st2rulesengine .nodeSelector, .tolerations, .affinity
+#   st2timersengine .nodeSelector, .tolerations, .affinity
+#   st2workflowengine .nodeSelector, .tolerations, .affinity
+#   st2scheduler .nodeSelector, .tolerations, .affinity
+#   st2notifier .nodeSelector, .tolerations, .affinity
+#   st2actionrunner .nodeSelector, .tolerations, .affinity
+#   st2sensorcontainer .nodeSelector, .tolerations, .affinity
+#   st2garbagecollector .nodeSelector, .tolerations, .affinity
+#   st2chatops .nodeSelector, .tolerations, .affinity
+#   jobs .nodeSelector, .tolerations, .affinity
+
+tests:
+  - it: Deployments and Jobs have no default placement
+    templates:
+      - deployments.yaml
+        # st2auth, st2api,
+        # st2stream, st2web,
+        # st2rulesengine, st2timersengine,
+        # st2workflowengine, st2scheduler,
+        # st2notifier, (1) st2sensorcontainer,
+        # st2actionrunner, st2garbagecollector,
+        # st2client, st2chatops
+      - jobs.yaml
+        # job-st2-apply-rbac-defintions
+        # job-st2-apikey-load
+        # job-st2-key-load
+        # job-st2-register-content
+    set:
+      st2:
+        rbac: { enabled: true } # enable rbac job
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.nodeSelector
+      - isNull:
+          path: spec.template.spec.tolerations
+      - isNull:
+          path: spec.template.spec.affinity
+
+  - it: Deployments and Jobs accept custom placement
+    templates:
+      - deployments.yaml
+        # st2auth, st2api,
+        # st2stream, st2web,
+        # st2rulesengine, st2timersengine,
+        # st2workflowengine, st2scheduler,
+        # st2notifier, (1) st2sensorcontainer,
+        # st2actionrunner, st2garbagecollector,
+        # st2client, st2chatops
+      - jobs.yaml
+        # job-st2-apply-rbac-defintions
+        # job-st2-apikey-load
+        # job-st2-key-load
+        # job-st2-register-content
+    set:
+      st2:
+        rbac: { enabled: true } # enable rbac job
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2web:
+        # these examples come from the k8s docs
+        nodeSelector: &custom_nodeSelector
+          disktype: ssd
+        tolerations: &custom_tolerations
+          - key: "key1"
+            operator: "Equal"
+            value: "value1"
+            effect: "NoSchedule"
+          - key: "key1"
+            operator: "Equal"
+            value: "value1"
+            effect: "NoExecute"
+        affinity: &custom_affinity
+          podAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchExpressions:
+                - key: security
+                  operator: In
+                  values:
+                  - S1
+              topologyKey: topology.kubernetes.io/zone
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                  - key: security
+                    operator: In
+                    values:
+                    - S2
+                topologyKey: topology.kubernetes.io/zone
+      st2auth:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2api:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2stream:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2rulesengine:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2timersengine:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2workflowengine:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2scheduler:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2notifier:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2actionrunner:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2sensorcontainer:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2garbagecollector:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2client:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      st2chatops:
+        enabled: true
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+      jobs:
+        nodeSelector: *custom_nodeSelector
+        tolerations: *custom_tolerations
+        affinity: *custom_affinity
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector
+          value: *custom_nodeSelector
+      - equal:
+          path: spec.template.spec.tolerations
+          value: *custom_tolerations
+      - equal:
+          path: spec.template.spec.affinity
+          value: *custom_affinity

--- a/tests/unit/placement_test.yaml
+++ b/tests/unit/placement_test.yaml
@@ -17,22 +17,6 @@ templates:
   - secrets_st2auth.yaml
   - secrets_st2chatops.yaml
 
-# nodeSelector & tolerations & affinity:
-#   st2web .nodeSelector, .tolerations, .affinity
-#   st2auth .nodeSelector, .tolerations, .affinity
-#   st2api .nodeSelector, .tolerations, .affinity
-#   st2stream .nodeSelector, .tolerations, .affinity
-#   st2rulesengine .nodeSelector, .tolerations, .affinity
-#   st2timersengine .nodeSelector, .tolerations, .affinity
-#   st2workflowengine .nodeSelector, .tolerations, .affinity
-#   st2scheduler .nodeSelector, .tolerations, .affinity
-#   st2notifier .nodeSelector, .tolerations, .affinity
-#   st2actionrunner .nodeSelector, .tolerations, .affinity
-#   st2sensorcontainer .nodeSelector, .tolerations, .affinity
-#   st2garbagecollector .nodeSelector, .tolerations, .affinity
-#   st2chatops .nodeSelector, .tolerations, .affinity
-#   jobs .nodeSelector, .tolerations, .affinity
-
 tests:
   - it: Deployments and Jobs have no default placement
     templates:

--- a/tests/unit/post_start_script_test.yaml
+++ b/tests/unit/post_start_script_test.yaml
@@ -1,0 +1,285 @@
+---
+suite: postStart scripts
+templates:
+  # primary template files
+  - deployments.yaml
+  - configmaps_post-start-script.yaml
+
+  # included templates must also be listed
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+# st2.packs.sensors.postStartScript is not valid
+# post start script on all deployments (not on jobs)
+#   st2web.postStartScript
+#   st2auth.postStartScript
+#   st2api.postStartScript
+#   st2stream.postStartScript
+#   st2rulesengine.postStartScript
+#   st2timersengine.postStartScript
+#   st2workflowengine.postStartScript
+#   st2scheduler.postStartScript
+#   st2notifier.postStartScript
+#   st2actionrunner.postStartScript
+#   st2sensorcontainer.postStartScript
+#   st2garbagecollector.postStartScript
+#   st2client.postStartScript
+#   st2chatops.postStartScript
+
+tests:
+  - it: post-start script for st2actionrunner and st2client
+    template: configmaps_post-start-script.yaml
+    set:
+      st2:
+        system_user:
+          user: yelnats # stanley backwards for the test
+          # ssh_key_file should be /home/yelnats/.ssh/stanley_rsa
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ConfigMap
+      - isAPIVersion:
+          of: v1
+      - isNotEmpty:
+          path: data.[post-start.sh]
+      - equal:
+          path: data.[post-start.sh]
+          value: |
+            #!/bin/bash
+            mkdir -p /home/yelnats/.ssh
+            cp -L /home/yelnats/.ssh-key-vol/stanley_rsa /home/yelnats/.ssh/stanley_rsa
+            chown -R yelnats:yelnats /home/yelnats/.ssh
+            chmod 400 /home/yelnats/.ssh/stanley_rsa
+            chmod 500 /home/yelnats/.ssh
+
+  - it: custom post-start script
+    template: configmaps_post-start-script.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2web:
+        postStartScript: &custom_post_start_script
+          echo hello world
+      st2auth:
+        postStartScript: *custom_post_start_script
+      st2api:
+        postStartScript: *custom_post_start_script
+      st2stream:
+        postStartScript: *custom_post_start_script
+      st2rulesengine:
+        postStartScript: *custom_post_start_script
+      st2timersengine:
+        postStartScript: *custom_post_start_script
+      st2workflowengine:
+        postStartScript: *custom_post_start_script
+      st2scheduler:
+        postStartScript: *custom_post_start_script
+      st2notifier:
+        postStartScript: *custom_post_start_script
+      st2actionrunner:
+        postStartScript: *custom_post_start_script
+      st2sensorcontainer:
+        postStartScript: *custom_post_start_script
+      st2garbagecollector:
+        postStartScript: *custom_post_start_script
+      st2client:
+        postStartScript: *custom_post_start_script
+      st2chatops:
+        enabled: true
+        postStartScript: *custom_post_start_script
+    asserts:
+      - hasDocuments:
+          count: 14
+      - isKind:
+          of: ConfigMap
+      - isAPIVersion:
+          of: v1
+      - isNotEmpty:
+          path: data.[post-start.sh]
+      - matchRegex:
+          path: data.[post-start.sh]
+          # Could also match the shebang at the begginning
+          # but I'm not sure how to match more than one line.
+          pattern: echo hello world
+
+  - it: Deployments st2actionrunner and st2client have lifecycle.postStartScipt by default
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 14
+
+      # st2actionrunner and st2client do not have checksum annotations
+      # (even though they probably should)
+      - isNull: &assert_checksum
+          path: spec.template.metadata.annotations.[checksum/post-start-script]
+
+      # only st2actionrunner and st2client have default postStart scripts
+      - equal: &assert_lifecycle
+          path: spec.template.spec.containers[0].lifecycle.postStart
+          value:
+            exec:
+              command: ["/bin/bash", "/post-start.sh"]
+        documentIndex: 10
+      - equal: *assert_lifecycle
+        documentIndex: 12
+
+      - isNull: &assert_null_lifecycle
+          path: spec.template.spec.containers[0].lifecycle
+        documentIndex: 0
+      - isNull: *assert_null_lifecycle
+        documentIndex: 1
+      - isNull: *assert_null_lifecycle
+        documentIndex: 2
+      - isNull: *assert_null_lifecycle
+        documentIndex: 3
+      - isNull: *assert_null_lifecycle
+        documentIndex: 4
+      - isNull: *assert_null_lifecycle
+        documentIndex: 5
+      - isNull: *assert_null_lifecycle
+        documentIndex: 6
+      - isNull: *assert_null_lifecycle
+        documentIndex: 7
+      - isNull: *assert_null_lifecycle
+        documentIndex: 8
+      - isNull: *assert_null_lifecycle
+        documentIndex: 9
+      - isNull: *assert_null_lifecycle
+        documentIndex: 11
+      - isNull: *assert_null_lifecycle
+        documentIndex: 13
+
+      - contains: &assert_volume_mount
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: st2-post-start-script-vol
+            mountPath: /post-start.sh
+            subPath: post-start.sh
+        documentIndex: 10
+      - contains: *assert_volume_mount
+        documentIndex: 12
+
+      - notContains: *assert_volume_mount
+        documentIndex: 0
+      - notContains: *assert_volume_mount
+        documentIndex: 1
+      - notContains: *assert_volume_mount
+        documentIndex: 2
+      - notContains: *assert_volume_mount
+        documentIndex: 4
+      - notContains: *assert_volume_mount
+        documentIndex: 5
+      - notContains: *assert_volume_mount
+        documentIndex: 6
+      - notContains: *assert_volume_mount
+        documentIndex: 7
+      - notContains: *assert_volume_mount
+        documentIndex: 8
+      - notContains: *assert_volume_mount
+        documentIndex: 9
+      - notContains: *assert_volume_mount
+        documentIndex: 11
+
+      # st2web and st2chatops have no volumes (and can be null)
+      - isEmpty:
+          path: spec.template.spec.containers[0].volumeMounts
+        documentIndex: 3
+      - isEmpty:
+          path: spec.template.spec.containers[0].volumeMounts
+        documentIndex: 13
+
+      - contains: &assert_volume
+          path: spec.template.spec.volumes
+          content:
+            name: st2-post-start-script-vol
+            # we cannot easily validate the generated ConfigMap name
+            #configMap:
+            #  name: {{ .Release.Name }}-st2auth-post-start-script
+          any: true
+        documentIndex: 10
+      - contains: *assert_volume
+        documentIndex: 12
+
+      - notContains: *assert_volume
+        documentIndex: 0
+      - notContains: *assert_volume
+        documentIndex: 1
+      - notContains: *assert_volume
+        documentIndex: 2
+      - notContains: *assert_volume
+        documentIndex: 4
+      - notContains: *assert_volume
+        documentIndex: 5
+      - notContains: *assert_volume
+        documentIndex: 6
+      - notContains: *assert_volume
+        documentIndex: 7
+      - notContains: *assert_volume
+        documentIndex: 8
+      - notContains: *assert_volume
+        documentIndex: 9
+      - notContains: *assert_volume
+        documentIndex: 11
+
+      - isEmpty:
+          path: spec.template.spec.volumes
+        documentIndex: 3
+      - isEmpty:
+          path: spec.template.spec.volumes
+        documentIndex: 13
+
+  - it: Deployments accept custom lifecycle.postStartScipt
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2web:
+        postStartScript: *custom_post_start_script
+      st2auth:
+        postStartScript: *custom_post_start_script
+      st2api:
+        postStartScript: *custom_post_start_script
+      st2stream:
+        postStartScript: *custom_post_start_script
+      st2rulesengine:
+        postStartScript: *custom_post_start_script
+      st2timersengine:
+        postStartScript: *custom_post_start_script
+      st2workflowengine:
+        postStartScript: *custom_post_start_script
+      st2scheduler:
+        postStartScript: *custom_post_start_script
+      st2notifier:
+        postStartScript: *custom_post_start_script
+      st2actionrunner:
+        postStartScript: *custom_post_start_script
+      st2sensorcontainer:
+        postStartScript: *custom_post_start_script
+      st2garbagecollector:
+        postStartScript: *custom_post_start_script
+      st2client:
+        postStartScript: *custom_post_start_script
+      st2chatops:
+        enabled: true
+        postStartScript: *custom_post_start_script
+    asserts:
+      - hasDocuments:
+          count: 14
+
+      - isNotEmpty: *assert_checksum
+      - equal: *assert_lifecycle
+      - contains: *assert_volume_mount
+      - contains: *assert_volume
+

--- a/tests/unit/post_start_script_test.yaml
+++ b/tests/unit/post_start_script_test.yaml
@@ -65,8 +65,7 @@ tests:
       st2:
         packs: { sensors: [] } # ensure only 1 sensor
       st2web:
-        postStartScript: &custom_post_start_script
-          echo hello world
+        postStartScript: &custom_post_start_script echo hello world
       st2auth:
         postStartScript: *custom_post_start_script
       st2api:
@@ -105,9 +104,10 @@ tests:
           path: data.[post-start.sh]
       - matchRegex:
           path: data.[post-start.sh]
-          # Could also match the shebang at the begginning
-          # but I'm not sure how to match more than one line.
-          pattern: echo hello world
+          # (?m) = multi-line mode: ^ and $ match begin/end line in addition to begin/end text
+          # (?s) = let . match \n
+          # .*? = any character zero or more times, prefer fewer
+          pattern: '(?ms)^#!/bin/bash$.*?^echo hello world$'
 
   - it: Deployments st2actionrunner and st2client have lifecycle.postStartScipt by default
     template: deployments.yaml

--- a/tests/unit/post_start_script_test.yaml
+++ b/tests/unit/post_start_script_test.yaml
@@ -15,23 +15,6 @@ templates:
   - secrets_st2auth.yaml
   - secrets_st2chatops.yaml
 
-# st2.packs.sensors.postStartScript is not valid
-# post start script on all deployments (not on jobs)
-#   st2web.postStartScript
-#   st2auth.postStartScript
-#   st2api.postStartScript
-#   st2stream.postStartScript
-#   st2rulesengine.postStartScript
-#   st2timersengine.postStartScript
-#   st2workflowengine.postStartScript
-#   st2scheduler.postStartScript
-#   st2notifier.postStartScript
-#   st2actionrunner.postStartScript
-#   st2sensorcontainer.postStartScript
-#   st2garbagecollector.postStartScript
-#   st2client.postStartScript
-#   st2chatops.postStartScript
-
 tests:
   - it: post-start script for st2actionrunner and st2client
     template: configmaps_post-start-script.yaml
@@ -265,6 +248,7 @@ tests:
         postStartScript: *custom_post_start_script
       st2actionrunner:
         postStartScript: *custom_post_start_script
+      # st2.packs.sensors.postStartScript is not valid
       st2sensorcontainer:
         postStartScript: *custom_post_start_script
       st2garbagecollector:

--- a/tests/unit/resources_test.yaml
+++ b/tests/unit/resources_test.yaml
@@ -1,0 +1,128 @@
+---
+suite: Resources
+templates:
+  # primary template files
+  - deployments.yaml
+
+  # No jobs resources yet
+
+  # included templates must also be listed
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+tests:
+  - it: Deployments have default resources
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 14
+
+      # only st2web defines limits for now
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].resources.limits.memory
+        documentIndex: 3
+
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].resources.requests.memory
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+
+  - it: Deployments accept custom resources (except st2client)
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2web:
+        resources:
+          # bogus numbers just for the test
+          requests: &custom_resources_requests
+            memory:  "333Mi"
+            cpu:  "77m"
+          limits:
+            memory: "999Mi"
+      st2auth:
+        resources: &custom_resources
+          requests: *custom_resources_requests
+      st2api:
+        resources: *custom_resources
+      st2stream:
+        resources: *custom_resources
+      st2rulesengine:
+        resources: *custom_resources
+      st2timersengine:
+        resources: *custom_resources
+      st2workflowengine:
+        resources: *custom_resources
+      st2scheduler:
+        resources: *custom_resources
+      st2notifier:
+        resources: *custom_resources
+      st2actionrunner:
+        resources: *custom_resources
+      st2sensorcontainer:
+        resources: *custom_resources
+      st2garbagecollector:
+        resources: *custom_resources
+      st2chatops:
+        enabled: true
+        resources: *custom_resources
+    asserts:
+      - hasDocuments:
+          count: 14
+
+      # only st2web defines limits for now
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "999Mi"
+        documentIndex: 3
+
+      # st2client hard codes resources.requests
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests
+          value:
+            memory: "5Mi"
+            cpu: "5m"
+        documentIndex: 12
+
+      # all but st2client means documentIndexes 0-11,13
+      - equal: &assert_custom_requests
+          path: spec.template.spec.containers[0].resources.requests
+          value: *custom_resources_requests
+        documentIndex: 0
+      - equal: *assert_custom_requests
+        documentIndex: 1
+      - equal: *assert_custom_requests
+        documentIndex: 2
+      - equal: *assert_custom_requests
+        documentIndex: 3
+      - equal: *assert_custom_requests
+        documentIndex: 4
+      - equal: *assert_custom_requests
+        documentIndex: 5
+      - equal: *assert_custom_requests
+        documentIndex: 6
+      - equal: *assert_custom_requests
+        documentIndex: 7
+      - equal: *assert_custom_requests
+        documentIndex: 8
+      - equal: *assert_custom_requests
+        documentIndex: 9
+      - equal: *assert_custom_requests
+        documentIndex: 10
+      - equal: *assert_custom_requests
+        documentIndex: 11
+      - equal: *assert_custom_requests
+        documentIndex: 13
+
+  # Jobs do not have default resources defined yet.

--- a/tests/unit/security_context_test.yaml
+++ b/tests/unit/security_context_test.yaml
@@ -1,0 +1,216 @@
+---
+suite: Custom SecurityContext
+templates:
+  # primary template files
+  - deployments.yaml
+  - jobs.yaml
+
+  # included templates must also be listed
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2-urls.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2apikeys.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+tests:
+  - it: Deployment and Job Pods+Containers have no SecurityContext by default
+    templates:
+      - deployments.yaml
+          # st2auth, st2api,
+          # st2stream, st2web,
+          # st2rulesengine, st2timersengine,
+          # st2workflowengine, st2scheduler,
+          # st2notifier, (1) st2sensorcontainer,
+          # st2actionrunner, st2garbagecollector,
+          # st2client, st2chatops
+      - jobs.yaml
+          # job-st2-apply-rbac-defintions
+          # job-st2-apikey-load
+          # job-st2-key-load
+          # job-st2-register-content
+    set:
+      st2chatops:
+        enabled: true
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+        rbac: { enabled: true } # enable rbac job
+
+      podSecurityContext: {}
+      securityContext: {}
+
+    asserts:
+      # pod
+      - isNull:
+          path: spec.template.spec.securityContext
+      # container
+      - isNull:
+          path: 'spec.template.spec.containers[0].securityContext'
+      # path can only select one element, not all initContainers (if present).
+      #- isNull:
+      #    path: 'spec.template.spec.initContainers[].securityContext'
+
+  - it: Deployment and Job Pods+Containers use same SecurityContext when defined
+    templates:
+      - deployments.yaml
+          # st2auth, st2api,
+          # st2stream, st2web,
+          # st2rulesengine, st2timersengine,
+          # st2workflowengine, st2scheduler,
+          # st2notifier, (1) st2sensorcontainer,
+          # st2actionrunner, st2garbagecollector,
+          # st2client, st2chatops
+      - jobs.yaml
+          # job-st2-apply-rbac-defintions
+          # job-st2-apikey-load
+          # job-st2-key-load
+          # job-st2-register-content
+    set:
+      st2chatops:
+        enabled: true
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+        rbac: { enabled: true } # enable rbac job
+
+      podSecurityContext: &global_pod_security_context
+        fsGroup: 1234
+        supplementalGroups: [5678]
+      securityContext: &global_security_context
+        capabilities:
+          drop: [ALL]
+
+    asserts:
+
+      # pod
+      - equal:
+          path: spec.template.spec.securityContext
+          value: *global_pod_security_context
+      # container
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value: *global_security_context
+      # path can only select one element, not all initContainers (if present).
+      #- equal:
+      #    path: spec.template.spec.initContainers[].securityContext
+      #    value: *global_security_context
+
+  # overrides for st2web, st2actionrunner, st2sensorcontainer, st2client
+  # document indexes: 3, 10, 9, 12
+
+  - it: Deployment Pod+Containers accept SecurityContext overrides
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+        rbac: { enabled: true } # enable rbac job
+
+      podSecurityContext: *global_pod_security_context
+      securityContext: *global_security_context
+
+      st2web:
+        podSecurityContext: &pod_security_context_override
+          fsGroup: 9867
+          supplementalGroups: [5432]
+        securityContext: &security_context_override
+          capabilities:
+            drop: [ALL]
+            add: [kill,net_raw] 
+
+      st2actionrunner:
+        podSecurityContext: *pod_security_context_override
+        securityContext: *security_context_override
+
+      st2sensorcontainer:
+        podSecurityContext: *pod_security_context_override
+        securityContext: *security_context_override
+
+      st2client:
+        podSecurityContext: *pod_security_context_override
+        securityContext: *security_context_override
+    asserts:
+      - hasDocuments:
+          count: 13
+
+      # st2web pod
+      - notEqual: &global_pod_security_context_assert
+          path: spec.template.spec.securityContext
+          value: *global_pod_security_context
+        documentIndex: 3
+      - equal: &override_pod_security_context_assert
+          path: spec.template.spec.securityContext
+          value: *pod_security_context_override
+        documentIndex: 3
+
+      # st2web container
+      - notEqual: &global_container0_security_context_assert
+          path: spec.template.spec.containers[0].securityContext
+          value: *global_security_context
+        documentIndex: 3
+      - equal: &override_container0_security_context_assert
+          path: spec.template.spec.containers[0].securityContext
+          value: *security_context_override
+        documentIndex: 3
+      # path can only select one element, not all initContainers (if present).
+      #- notEqual: &global_initcontainers_security_context_assert
+      #    path: spec.template.spec.initContainers[].securityContext
+      #    value: *global_security_context
+      #  documentIndex: 3
+      #- equal: &override_initcontainers_security_context_assert
+      #    path: spec.template.spec.initContainers[].securityContext
+      #    value: *security_context_override
+      #  documentIndex: 3
+
+      # st2actionrunner pod
+      - notEqual: *global_pod_security_context_assert
+        documentIndex: 10
+      - equal: *override_pod_security_context_assert
+        documentIndex: 10
+
+      # st2actionrunner container
+      - notEqual: *global_container0_security_context_assert
+        documentIndex: 10
+      - equal: *override_container0_security_context_assert
+        documentIndex: 10
+      # path can only select one element, not all initContainers (if present).
+      #- notEqual: *global_initcontainers_security_context_assert
+      #  documentIndex: 10
+      #- equal: *override_initcontainers_security_context_assert
+      #  documentIndex: 10
+
+      # st2sensorcontainer pod
+      - notEqual: *global_pod_security_context_assert
+        documentIndex: 9
+      - equal: *override_pod_security_context_assert
+        documentIndex: 9
+
+      # st2sensorcontainer container
+      - notEqual: *global_container0_security_context_assert
+        documentIndex: 9
+      - equal: *override_container0_security_context_assert
+        documentIndex: 9
+      # path can only select one element, not all initContainers (if present).
+      #- notEqual: *global_initcontainers_security_context_assert
+      #  documentIndex: 9
+      #- equal: *override_initcontainers_security_context_assert
+      #  documentIndex: 9
+
+      # st2client pod
+      - notEqual: *global_pod_security_context_assert
+        documentIndex: 12
+      - equal: *override_pod_security_context_assert
+        documentIndex: 12
+
+      # st2client container
+      - notEqual: *global_container0_security_context_assert
+        documentIndex: 12
+      - equal: *override_container0_security_context_assert
+        documentIndex: 12
+      # path can only select one element, not all initContainers (if present).
+      #- notEqual: *global_initcontainers_security_context_assert
+      #  documentIndex: 12
+      #- equal: *override_initcontainers_security_context_assert
+      #  documentIndex: 12

--- a/tests/unit/security_context_test.yaml
+++ b/tests/unit/security_context_test.yaml
@@ -21,18 +21,18 @@ tests:
   - it: Deployment and Job Pods+Containers have no SecurityContext by default
     templates:
       - deployments.yaml
-          # st2auth, st2api,
-          # st2stream, st2web,
-          # st2rulesengine, st2timersengine,
-          # st2workflowengine, st2scheduler,
-          # st2notifier, (1) st2sensorcontainer,
-          # st2actionrunner, st2garbagecollector,
-          # st2client, st2chatops
+        # st2auth, st2api,
+        # st2stream, st2web,
+        # st2rulesengine, st2timersengine,
+        # st2workflowengine, st2scheduler,
+        # st2notifier, (1) st2sensorcontainer,
+        # st2actionrunner, st2garbagecollector,
+        # st2client, st2chatops
       - jobs.yaml
-          # job-st2-apply-rbac-defintions
-          # job-st2-apikey-load
-          # job-st2-key-load
-          # job-st2-register-content
+        # job-st2-apply-rbac-defintions
+        # job-st2-apikey-load
+        # job-st2-key-load
+        # job-st2-register-content
     set:
       st2chatops:
         enabled: true
@@ -49,7 +49,7 @@ tests:
           path: spec.template.spec.securityContext
       # container
       - isNull:
-          path: 'spec.template.spec.containers[0].securityContext'
+          path: "spec.template.spec.containers[0].securityContext"
       # path can only select one element, not all initContainers (if present).
       #- isNull:
       #    path: 'spec.template.spec.initContainers[].securityContext'
@@ -57,18 +57,18 @@ tests:
   - it: Deployment and Job Pods+Containers use same SecurityContext when defined
     templates:
       - deployments.yaml
-          # st2auth, st2api,
-          # st2stream, st2web,
-          # st2rulesengine, st2timersengine,
-          # st2workflowengine, st2scheduler,
-          # st2notifier, (1) st2sensorcontainer,
-          # st2actionrunner, st2garbagecollector,
-          # st2client, st2chatops
+        # st2auth, st2api,
+        # st2stream, st2web,
+        # st2rulesengine, st2timersengine,
+        # st2workflowengine, st2scheduler,
+        # st2notifier, (1) st2sensorcontainer,
+        # st2actionrunner, st2garbagecollector,
+        # st2client, st2chatops
       - jobs.yaml
-          # job-st2-apply-rbac-defintions
-          # job-st2-apikey-load
-          # job-st2-key-load
-          # job-st2-register-content
+        # job-st2-apply-rbac-defintions
+        # job-st2-apikey-load
+        # job-st2-key-load
+        # job-st2-register-content
     set:
       st2chatops:
         enabled: true
@@ -84,7 +84,6 @@ tests:
           drop: [ALL]
 
     asserts:
-
       # pod
       - equal:
           path: spec.template.spec.securityContext
@@ -118,7 +117,7 @@ tests:
         securityContext: &security_context_override
           capabilities:
             drop: [ALL]
-            add: [kill,net_raw] 
+            add: [kill, net_raw]
 
       st2actionrunner:
         podSecurityContext: *pod_security_context_override

--- a/tests/unit/service_account_test.yaml
+++ b/tests/unit/service_account_test.yaml
@@ -1,0 +1,217 @@
+---
+suite: ServiceAccount
+templates:
+  # primary template files
+  - service-account.yaml
+  - deployments.yaml
+
+  # ServiceAccount doesn't attach to Jobs
+
+  # included templates must also be listed
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+# ServiceAccount
+#   serviceAccount.create
+# attach ServiceAccount
+#   st2web: { serviceAccount: { attach: true } }
+#   st2auth: { serviceAccount: { attach: true } }
+#   st2api: { serviceAccount: { attach: true } }
+#   st2stream: { serviceAccount: { attach: true } }
+#   st2rulesengine: { serviceAccount: { attach: true } }
+#   st2timersengine: { serviceAccount: { attach: true } }
+#   st2workflowengine: { serviceAccount: { attach: true } }
+#   st2scheduler: { serviceAccount: { attach: true } }
+#   st2notifier: { serviceAccount: { attach: true } }
+#   st2actionrunner: { serviceAccount: { attach: true } }
+#   st2sensorcontainer: { serviceAccount: { attach: true } }
+#   st2garbagecollector: { serviceAccount: { attach: true } }
+#   st2chatops: { serviceAccount: { attach: true } }
+
+tests:
+  - it: ServiceAccount created by default
+    template: service-account.yaml
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ServiceAccount
+      - isAPIVersion:
+          of: v1
+      # service account name is chart name by default
+      - equal:
+          path: metadata.name
+          value: stackstorm-ha
+
+  - it: ServiceAccount creation can be disabled
+    template: service-account.yaml
+    set:
+      serviceAccount:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: Deployments do not attach ServiceAccount by default
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2chatops:
+        enabled: true
+    asserts:
+      - hasDocuments:
+          count: 14
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+
+  - it: Deployments can attach ServiceAccount with default name (except st2client)
+    template: deployments.yaml
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2web:
+        serviceAccount: &attach_sa
+          attach: true
+      st2auth:
+        serviceAccount: *attach_sa
+      st2api:
+        serviceAccount: *attach_sa
+      st2stream:
+        serviceAccount: *attach_sa
+      st2rulesengine:
+        serviceAccount: *attach_sa
+      st2timersengine:
+        serviceAccount: *attach_sa
+      st2workflowengine:
+        serviceAccount: *attach_sa
+      st2scheduler:
+        serviceAccount: *attach_sa
+      st2notifier:
+        serviceAccount: *attach_sa
+      st2actionrunner:
+        serviceAccount: *attach_sa
+      st2sensorcontainer:
+        serviceAccount: *attach_sa
+      st2garbagecollector:
+        serviceAccount: *attach_sa
+      st2chatops:
+        enabled: true
+        serviceAccount: *attach_sa
+    asserts:
+      - hasDocuments:
+          count: 14
+      # st2client does not allow attaching serviceAccount
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+        documentIndex: 12
+
+      # all but st2client means documentIndexes 0-11,13
+      - equal: &assert_sa_default
+          path: spec.template.spec.serviceAccountName
+          value: stackstorm-ha
+        documentIndex: 0
+      - equal: *assert_sa_default
+        documentIndex: 1
+      - equal: *assert_sa_default
+        documentIndex: 2
+      - equal: *assert_sa_default
+        documentIndex: 3
+      - equal: *assert_sa_default
+        documentIndex: 4
+      - equal: *assert_sa_default
+        documentIndex: 5
+      - equal: *assert_sa_default
+        documentIndex: 6
+      - equal: *assert_sa_default
+        documentIndex: 7
+      - equal: *assert_sa_default
+        documentIndex: 8
+      - equal: *assert_sa_default
+        documentIndex: 9
+      - equal: *assert_sa_default
+        documentIndex: 10
+      - equal: *assert_sa_default
+        documentIndex: 11
+      - equal: *assert_sa_default
+        documentIndex: 13
+
+
+  - it: Deployments can attach ServiceAccount with alternate name (except st2client)
+    template: deployments.yaml
+    set:
+      serviceAccount:
+        serviceAccountName: custom-service-account
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+      st2web:
+        serviceAccount: *attach_sa
+      st2auth:
+        serviceAccount: *attach_sa
+      st2api:
+        serviceAccount: *attach_sa
+      st2stream:
+        serviceAccount: *attach_sa
+      st2rulesengine:
+        serviceAccount: *attach_sa
+      st2timersengine:
+        serviceAccount: *attach_sa
+      st2workflowengine:
+        serviceAccount: *attach_sa
+      st2scheduler:
+        serviceAccount: *attach_sa
+      st2notifier:
+        serviceAccount: *attach_sa
+      st2actionrunner:
+        serviceAccount: *attach_sa
+      st2sensorcontainer:
+        serviceAccount: *attach_sa
+      st2garbagecollector:
+        serviceAccount: *attach_sa
+      st2chatops:
+        enabled: true
+        serviceAccount: *attach_sa
+    asserts:
+      - hasDocuments:
+          count: 14
+      # st2client does not allow attaching serviceAccount
+      - isNull:
+          path: spec.template.spec.serviceAccountName
+        documentIndex: 12
+
+      # all but st2client means documentIndexes 0-11,13
+      - equal: &assert_sa_custom
+          path: spec.template.spec.serviceAccountName
+          value: custom-service-account
+        documentIndex: 0
+      - equal: *assert_sa_custom
+        documentIndex: 1
+      - equal: *assert_sa_custom
+        documentIndex: 2
+      - equal: *assert_sa_custom
+        documentIndex: 3
+      - equal: *assert_sa_custom
+        documentIndex: 4
+      - equal: *assert_sa_custom
+        documentIndex: 5
+      - equal: *assert_sa_custom
+        documentIndex: 6
+      - equal: *assert_sa_custom
+        documentIndex: 7
+      - equal: *assert_sa_custom
+        documentIndex: 8
+      - equal: *assert_sa_custom
+        documentIndex: 9
+      - equal: *assert_sa_custom
+        documentIndex: 10
+      - equal: *assert_sa_custom
+        documentIndex: 11
+      - equal: *assert_sa_custom
+        documentIndex: 13
+

--- a/tests/unit/service_account_test.yaml
+++ b/tests/unit/service_account_test.yaml
@@ -17,23 +17,6 @@ templates:
   - secrets_st2auth.yaml
   - secrets_st2chatops.yaml
 
-# ServiceAccount
-#   serviceAccount.create
-# attach ServiceAccount
-#   st2web: { serviceAccount: { attach: true } }
-#   st2auth: { serviceAccount: { attach: true } }
-#   st2api: { serviceAccount: { attach: true } }
-#   st2stream: { serviceAccount: { attach: true } }
-#   st2rulesengine: { serviceAccount: { attach: true } }
-#   st2timersengine: { serviceAccount: { attach: true } }
-#   st2workflowengine: { serviceAccount: { attach: true } }
-#   st2scheduler: { serviceAccount: { attach: true } }
-#   st2notifier: { serviceAccount: { attach: true } }
-#   st2actionrunner: { serviceAccount: { attach: true } }
-#   st2sensorcontainer: { serviceAccount: { attach: true } }
-#   st2garbagecollector: { serviceAccount: { attach: true } }
-#   st2chatops: { serviceAccount: { attach: true } }
-
 tests:
   - it: ServiceAccount created by default
     template: service-account.yaml

--- a/tests/unit/st2sensors_test.yaml
+++ b/tests/unit/st2sensors_test.yaml
@@ -1,0 +1,249 @@
+---
+suite: Sensors
+templates:
+  # primary template files
+  - deployments.yaml
+
+  # included templates must also be listed
+  - configmaps_packs.yaml
+  - configmaps_rbac.yaml
+  - configmaps_st2-conf.yaml
+  - configmaps_st2web.yaml
+  - secrets_datastore_crypto_key.yaml
+  - secrets_ssh.yaml
+  - secrets_st2auth.yaml
+  - secrets_st2chatops.yaml
+
+tests:
+  - it: stackstorm/sensor-mode = all-sensors-in-one-pod
+    template: deployments.yaml
+    release:
+      name: foo-release
+    set:
+      st2:
+        packs: { sensors: [] } # ensure only 1 sensor
+    asserts:
+      - hasDocuments:
+          count: 13 # all but st2chatops
+
+      - isKind:
+          of: Deployment
+        documentIndex: &first_sensor_doc 9
+
+      - equal:
+          path: metadata.name
+          value: foo-release-st2sensorcontainer
+        documentIndex: *first_sensor_doc
+
+      - equal:
+          path: metadata.labels.app
+          value: st2sensorcontainer
+        documentIndex: *first_sensor_doc
+
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: st2sensorcontainer
+        documentIndex: *first_sensor_doc
+
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: st2sensorcontainer
+        documentIndex: *first_sensor_doc
+
+      - equal:
+          path: spec.replicas
+          # sensors should never have more than 1 replica
+          value: 1
+        documentIndex: *first_sensor_doc
+
+      - equal:
+          path: spec.template.metadata.annotations.stackstorm/sensor-mode
+          value: all-sensors-in-one-pod
+        documentIndex: *first_sensor_doc
+
+      - isNull:
+          path: spec.template.spec.containers[0].command
+      #- notContains:
+      #    path: spec.template.spec.containers[0].command
+      #    content: '--single-sensor-mode'
+        documentIndex: *first_sensor_doc
+
+  - it: stackstorm/sensor-mode = one-sensor-per-pod
+    template: deployments.yaml
+    release:
+      name: foobarbaz-release
+    set:
+      image:
+        tag: globaldefault
+      st2sensorcontainer:
+        image:
+          tag: sensordefault
+      st2:
+        packs:
+          sensors:
+            # we define image.tag and securityContext to test overrides
+            - name: foo
+              ref: some_pack.foo_sensor
+              image:
+                tag: "{{ .Values.image.tag }}templated"
+            - name: bar
+              ref: some_pack.bar_sensor
+            - name: baz
+              ref: some_pack.baz_sensor
+              image:
+                tag: baz
+              securityContext: &override_security_context
+                allowPrivilegeEscalation: false
+      securityContext: &global_security_context
+        capabilities:
+          drop: [ALL]
+    asserts:
+      - hasDocuments:
+          count: 15 # all but st2chatops
+
+      - isKind:
+          of: Deployment
+        documentIndex: *first_sensor_doc
+      - isKind:
+          of: Deployment
+        documentIndex: &second_sensor_doc 10
+      - isKind:
+          of: Deployment
+        documentIndex: &third_sensor_doc 11
+
+      - equal:
+          path: metadata.name
+          value: foobarbaz-release-st2sensorcontainer-foo
+        documentIndex: *first_sensor_doc
+      - equal:
+          path: metadata.name
+          value: foobarbaz-release-st2sensorcontainer-bar
+        documentIndex: *second_sensor_doc
+      - equal:
+          path: metadata.name
+          value: foobarbaz-release-st2sensorcontainer-baz
+        documentIndex: *third_sensor_doc
+
+      - equal:
+          path: metadata.labels.app
+          value: st2sensorcontainer-foo
+        documentIndex: *first_sensor_doc
+      - equal:
+          path: metadata.labels.app
+          value: st2sensorcontainer-bar
+        documentIndex: *second_sensor_doc
+      - equal:
+          path: metadata.labels.app
+          value: st2sensorcontainer-baz
+        documentIndex: *third_sensor_doc
+
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: st2sensorcontainer-foo
+        documentIndex: *first_sensor_doc
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: st2sensorcontainer-bar
+        documentIndex: *second_sensor_doc
+      - equal:
+          path: spec.template.metadata.labels.app
+          value: st2sensorcontainer-baz
+        documentIndex: *third_sensor_doc
+
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: st2sensorcontainer-foo
+        documentIndex: *first_sensor_doc
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: st2sensorcontainer-bar
+        documentIndex: *second_sensor_doc
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: st2sensorcontainer-baz
+        documentIndex: *third_sensor_doc
+
+      - equal: &oneReplica
+          path: spec.replicas
+          # sensors should never have more than 1 replica
+          value: 1
+        documentIndex: *first_sensor_doc
+      - equal: *oneReplica
+        documentIndex: *second_sensor_doc
+      - equal: *oneReplica
+        documentIndex: *third_sensor_doc
+
+      - equal: &oneSensorAnnotation
+          path: spec.template.metadata.annotations.stackstorm/sensor-mode
+          value: one-sensor-per-pod
+        documentIndex: *first_sensor_doc
+      - equal: *oneSensorAnnotation
+        documentIndex: *second_sensor_doc
+      - equal: *oneSensorAnnotation
+        documentIndex: *third_sensor_doc
+
+      - contains: &singleSensorMode
+          path: spec.template.spec.containers[0].command
+          content: '--single-sensor-mode'
+        documentIndex: *first_sensor_doc
+      - contains: *singleSensorMode
+        documentIndex: *second_sensor_doc
+      - contains: *singleSensorMode
+        documentIndex: *third_sensor_doc
+
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: '--sensor-ref=some_pack.foo_sensor'
+        documentIndex: *first_sensor_doc
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: '--sensor-ref=some_pack.bar_sensor'
+        documentIndex: *second_sensor_doc
+      - contains:
+          path: spec.template.spec.containers[0].command
+          content: '--sensor-ref=some_pack.baz_sensor'
+        documentIndex: *third_sensor_doc
+
+      # make sure value overrides work
+      # global default > st2sensorcontainer > st2.pack.sensors
+      # and helm templating works
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '.*:globaldefaulttemplated$'
+        documentIndex: *first_sensor_doc
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '.*:sensordefault$'
+        documentIndex: *second_sensor_doc
+      - matchRegex:
+          path: spec.template.spec.containers[0].image
+          pattern: '.*:baz$'
+        documentIndex: *third_sensor_doc
+
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value: *global_security_context
+        documentIndex: *first_sensor_doc
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value: *global_security_context
+        documentIndex: *second_sensor_doc
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value: *override_security_context
+        documentIndex: *third_sensor_doc
+
+  - it: stackstorm/sensor-mode = one-sensor-per-pod fails for missing sensor ref
+    template: deployments.yaml
+    release:
+      name: missing-sensor-ref-release
+    set:
+      st2:
+        packs:
+          sensors:
+            - name: foo
+              ref: some_pack.foo_sensor
+            - name: bar
+    asserts:
+      - failedTemplate:
+          errorMessage: "You must define `ref` for everything in st2.packs.sensors. This assigns each sensor to a pod."


### PR DESCRIPTION
Part of #28

- correct helm unittest usage with more than one test file
- Add unit tests for
    - required Labels
    - SecurityContext
    - imagePullSecrets and PullPolicy
    - Resources
    - Pod placement (NodeSelector, Tolerations, Affinity)
    - dnsConfig, dnsPolicy
    - ServiceAccount
    - postStartScript