### PR TITLE
Allow "external" st2api, st2auth, and st2stream Services (LoadBalancer type with hostname)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
 * Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, dnsConfig, ServiceAccount attach, postStartScript, and both sensor-modes. (#284, #288)
-* New feature to include possibility for external services in st2api and st2auth, setting default value for this services as `ClusterIP` and `hostname: ""`. (by @sandesvitor)
+* New feature to include possibility for external services in st2api, st2stream and st2auth, setting default value for this services as `ClusterIP` and `hostname: ""`. (by @sandesvitor)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
 * Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, dnsConfig, ServiceAccount attach, postStartScript, and both sensor-modes. (#284, #288)
 * Allow partitioning sensors using the hash_range strategy instead of one sensor per pod. (#218) (by @cognifloyd)
-* New feature to include possibility for external services in st2api, st2stream and st2auth, setting default value for this services as `ClusterIP` and `hostname: ""`. (by @sandesvitor)
+* New feature to include possibility for external services in st2api, st2stream and st2auth, setting default value for this services as `ClusterIP` and `hostname: ""`. Also, added new entry for custom_annotations_test.yaml and created new unit test services_test.yaml. (by @sandesvitor)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Prefix template helpers with chart name and format helper comments as template comments. (#272) (by @cognifloyd)
 * New feature: Add `extra_volumes` to all python-based st2 deployments. This can facilitate changing log levels by loading logging conf file(s) from a custom ConfigMap. (#276) (by @cognifloyd)
 * Initialize basic unittest infrastructure using `helm-unittest`. Added tests for labels, custom annotations, SecurityContext, pullSecrets, pullPolicy, Resources, nodeSelector, tolerations, affinity, dnsPolicy, dnsConfig, ServiceAccount attach, postStartScript, and both sensor-modes. (#284, #288)
+* New feature to include possibility for external services in st2api and st2auth, setting default value for this services as `ClusterIP` and `hostname: ""`. (by @sandesvitor)
 
 ## v0.80.0
 * Switch st2 to `v3.6` as a new default stable version (#274)

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -39,7 +39,7 @@ metadata:
   name: {{ .Release.Name }}-st2api
   annotations:
     description: StackStorm st2api - service hosts the REST API endpoints that serve requests from WebUI, CLI, ChatOps and other st2 services.
-    {{- if .Values.st2web.service.hostname }}
+    {{- if .Values.st2api.service.hostname }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.st2api.service.hostname | quote }}
     {{- end }}
     {{- if .Values.st2api.service.annotations }}

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -28,6 +28,12 @@ metadata:
   name: {{ .Release.Name }}-st2api
   annotations:
     description: StackStorm st2api - service hosts the REST API endpoints that serve requests from WebUI, CLI, ChatOps and other st2 services.
+    {{- if .Values.st2web.service.hostname }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.st2api.service.hostname | quote }}
+    {{- end }}
+    {{- if .Values.st2api.service.annotations }}
+      {{- toYaml .Values.st2api.service.annotations | nindent 4 }}
+    {{- end }}
   labels:
     app: st2api
     tier: backend
@@ -39,7 +45,12 @@ spec:
   selector:
     app: st2api
     release: {{ .Release.Name }}
-  type: ClusterIP
+  type: {{ .Values.st2api.service.type }}
+  {{- if contains "ExternalName" .Values.st2api.service.type }}
+  {{- if .Values.st2api.service.hostname }}
+  externalName: {{ .Values.st2api.service.hostname }}
+  {{- end }}
+  {{- end }}
   ports:
   - protocol: TCP
     port: 9101
@@ -125,3 +136,34 @@ spec:
   - protocol: TCP
     port: 8081
 {{- end }}
+
+---
+kind: Service
+apiVersion: v1
+metadata:
+  name: {{ .Release.Name }}-st2client
+  annotations:
+    description: StackStorm st2client
+    {{- if .Values.st2client.service.hostname }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.st2client.service.hostname | quote }}
+    {{- end }}
+    {{- if .Values.st2client.service.annotations }}
+      {{- toYaml .Values.st2client.service.annotations | nindent 4 }}
+    {{- end }}
+  labels:
+    app: st2client
+    tier: frontend
+    vendor: stackstorm
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  selector:
+    app: st2client
+    release: {{ .Release.Name }}
+  type: {{ .Values.st2client.service.type }}
+  {{- if contains "ExternalName" .Values.st2client.service.type }}
+  {{- if .Values.st2client.service.hostname }}
+  externalName: {{ .Values.st2client.service.hostname }}
+  {{- end }}
+  {{- end }}

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -5,6 +5,12 @@ metadata:
   name: {{ .Release.Name }}-st2auth
   annotations:
     description: StackStorm st2auth - all authentication is managed by this service.
+    {{- if .Values.st2auth.service.hostname }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.st2auth.service.hostname | quote }}
+    {{- end }}
+    {{- if .Values.st2auth.service.annotations }}
+      {{- toYaml .Values.st2auth.service.annotations | nindent 4 }}
+    {{- end }}
   labels:
     app: st2auth
     tier: backend
@@ -16,7 +22,12 @@ spec:
   selector:
     app: st2auth
     release: {{ .Release.Name }}
-  type: ClusterIP
+  type: {{ .Values.st2auth.service.type }}
+  {{- if contains "ExternalName" .Values.st2auth.service.type }}
+  {{- if .Values.st2auth.service.hostname }}
+  externalName: {{ .Values.st2auth.service.hostname }}
+  {{- end }}
+  {{- end }}
   ports:
   - protocol: TCP
     port: 9100
@@ -136,34 +147,3 @@ spec:
   - protocol: TCP
     port: 8081
 {{- end }}
-
----
-kind: Service
-apiVersion: v1
-metadata:
-  name: {{ .Release.Name }}-st2client
-  annotations:
-    description: StackStorm st2client
-    {{- if .Values.st2client.service.hostname }}
-    external-dns.alpha.kubernetes.io/hostname: {{ .Values.st2client.service.hostname | quote }}
-    {{- end }}
-    {{- if .Values.st2client.service.annotations }}
-      {{- toYaml .Values.st2client.service.annotations | nindent 4 }}
-    {{- end }}
-  labels:
-    app: st2client
-    tier: frontend
-    vendor: stackstorm
-    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
-spec:
-  selector:
-    app: st2client
-    release: {{ .Release.Name }}
-  type: {{ .Values.st2client.service.type }}
-  {{- if contains "ExternalName" .Values.st2client.service.type }}
-  {{- if .Values.st2client.service.hostname }}
-  externalName: {{ .Values.st2client.service.hostname }}
-  {{- end }}
-  {{- end }}

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -73,7 +73,7 @@ metadata:
   name: {{ .Release.Name }}-st2stream
   annotations:
     description: StackStorm st2stream - exposes a server-sent event stream, used by the clients like WebUI and ChatOps to receive update from the st2stream server.
-    {- if .Values.st2stream.service.hostname }}
+    {{- if .Values.st2stream.service.hostname }}
     external-dns.alpha.kubernetes.io/hostname: {{ .Values.st2stream.service.hostname | quote }}
     {{- end }}
     {{- if .Values.st2stream.service.annotations }}

--- a/templates/services.yaml
+++ b/templates/services.yaml
@@ -73,6 +73,12 @@ metadata:
   name: {{ .Release.Name }}-st2stream
   annotations:
     description: StackStorm st2stream - exposes a server-sent event stream, used by the clients like WebUI and ChatOps to receive update from the st2stream server.
+    {- if .Values.st2stream.service.hostname }}
+    external-dns.alpha.kubernetes.io/hostname: {{ .Values.st2stream.service.hostname | quote }}
+    {{- end }}
+    {{- if .Values.st2stream.service.annotations }}
+      {{- toYaml .Values.st2stream.service.annotations | nindent 4 }}
+    {{- end }}
   labels:
     app: st2stream
     tier: backend
@@ -84,7 +90,12 @@ spec:
   selector:
     app: st2stream
     release: {{ .Release.Name }}
-  type: ClusterIP
+  type: {{ .Values.st2stream.service.type }}
+  {{- if contains "ExternalName" .Values.st2stream.service.type }}
+  {{- if .Values.st2stream.service.hostname }}
+  externalName: {{ .Values.st2stream.service.hostname }}
+  {{- end }}
+  {{- end }}
   ports:
   - protocol: TCP
     port: 9102

--- a/tests/unit/custom_annotations_test.yaml
+++ b/tests/unit/custom_annotations_test.yaml
@@ -52,7 +52,7 @@ tests:
 
   # st2auth, st2api, st2stream services do not accept custom annotations
 
-  - it: st2web, st2auth, st2api and st2stream Services accepts custom annotations
+  - it: st2web, st2auth, st2api and st2stream Services accept custom annotations
     template: services.yaml
     set:
       st2web:

--- a/tests/unit/custom_annotations_test.yaml
+++ b/tests/unit/custom_annotations_test.yaml
@@ -72,6 +72,8 @@ tests:
         service:
           hostname: some-host-name
           annotations: *annotations
+      st2chatops:
+        enabled: false # exclude st2chatops to only test other services
     asserts: *annotations_asserts
 
   # st2chatops service does not accept custom annotations

--- a/tests/unit/custom_annotations_test.yaml
+++ b/tests/unit/custom_annotations_test.yaml
@@ -52,9 +52,8 @@ tests:
 
   # st2auth, st2api, st2stream services do not accept custom annotations
 
-  - it: st2web, st2auth, st2api ans st2stream Services accepts custom annotations
+  - it: st2web, st2auth, st2api and st2stream Services accepts custom annotations
     template: services.yaml
-    documentIndex: 3
     set:
       st2web:
         service:

--- a/tests/unit/custom_annotations_test.yaml
+++ b/tests/unit/custom_annotations_test.yaml
@@ -52,11 +52,23 @@ tests:
 
   # st2auth, st2api, st2stream services do not accept custom annotations
 
-  - it: st2web Service accepts custom annotations
+  - it: st2web, st2auth, st2api ans st2stream Services accepts custom annotations
     template: services.yaml
     documentIndex: 3
     set:
       st2web:
+        service:
+          hostname: some-host-name
+          annotations: *annotations
+      st2api:
+        service:
+          hostname: some-host-name
+          annotations: *annotations
+      st2auth:
+        service:
+          hostname: some-host-name
+          annotations: *annotations
+      st2stream:
         service:
           hostname: some-host-name
           annotations: *annotations

--- a/tests/unit/services_test.yaml
+++ b/tests/unit/services_test.yaml
@@ -14,8 +14,6 @@ tests:
           count: 4
       - isNull:
           path: spec.externalName
-          value: some-host-name
-
   
   - it: st2web, st2auth, st2api, st2stream should work with externalName if type is ExternalName
     set:

--- a/tests/unit/services_test.yaml
+++ b/tests/unit/services_test.yaml
@@ -1,20 +1,49 @@
 ---
-suite: Services hostname and type
+suite: Services
 templates:
   # primary template files
   - services.yaml
 
 tests:
-  - it: st2web, st2auth, st2api, st2stream should work without hostname 
+  - it: st2web, st2auth, st2api, st2stream should work without externalName
+    set:
+      st2chatops:
+        enabled: false 
+    asserts:
+      - hasDocuments:
+          count: 4
+      - isNull:
+          path: spec.externalName
+          value: some-host-name
+
+  
+  - it: st2web, st2auth, st2api, st2stream should work with externalName if type is ExternalName
     set:
       st2web:
         service:
           hostname: some-host-name
-          type: LoadBalancer
+          type: ExternalName
+      st2auth:
+        service:
+          hostname: some-host-name
+          type: ExternalName
+      st2api:
+        service:
+          hostname: some-host-name
+          type: ExternalName
+      st2stream:
+        service:
+          hostname: some-host-name
+          type: ExternalName
+      st2chatops:
+        enabled: false 
     asserts:
+      - hasDocuments:
+          count: 4
       - equal:
-        path: spec.type
-        value: LoadBalancer
+          path: spec.type
+          value: ExternalName
       - equal:
-        path: spec.externalName
-        value: some-host-name
+          path: spec.externalName
+          value: some-host-name
+

--- a/tests/unit/services_test.yaml
+++ b/tests/unit/services_test.yaml
@@ -1,0 +1,20 @@
+---
+suite: Services hostname and type
+templates:
+  # primary template files
+  - services.yaml
+
+tests:
+  - it: st2web, st2auth, st2api, st2stream should work without hostname 
+    set:
+      st2web:
+        service:
+          hostname: some-host-name
+          type: LoadBalancer
+    asserts:
+      - equal:
+        path: spec.type
+        value: LoadBalancer
+      - equal:
+        path: spec.externalName
+        value: some-host-name

--- a/values.yaml
+++ b/values.yaml
@@ -425,6 +425,14 @@ st2stream:
   affinity: {}
   env: {}
   # HTTP_PROXY: http://proxy:1234
+  service:
+    # type can be one of "ClusterIP", "NodePort", "LoadBalancer" or "ExternalName"
+    type: "ClusterIP"
+    # The hostname associated with st2api service (externalName, added to external DNS, etc.)
+    hostname: ""
+    # For more information regarding annotations, see
+    # https://kubernetes.io/docs/concepts/services-networking/service/#ssl-support-on-aws
+    annotations: {}
   serviceAccount:
     attach: false
   # postStartScript is optional. It has the contents of a bash script.

--- a/values.yaml
+++ b/values.yaml
@@ -347,6 +347,14 @@ st2auth:
   affinity: {}
   env: {}
   # HTTP_PROXY: http://proxy:1234
+  service:
+    # type can be one of "ClusterIP", "NodePort", "LoadBalancer" or "ExternalName"
+    type: "ClusterIP"
+    # The hostname associated with st2auth service (externalName, added to external DNS, etc.)
+    hostname: ""
+    # For more information regarding annotations, see
+    # https://kubernetes.io/docs/concepts/services-networking/service/#ssl-support-on-aws
+    annotations: {}
   serviceAccount:
     attach: false
   # postStartScript is optional. It has the contents of a bash script.
@@ -714,14 +722,6 @@ st2client:
     username = ${ST2_AUTH_USERNAME}
     password = ${ST2_AUTH_PASSWORD}
   env: {}
-  service:
-    # type can be one of "ClusterIP", "NodePort", "LoadBalancer" or "ExternalName"
-    type: "ClusterIP"
-    # The hostname associated with st2client service (externalName, added to external DNS, etc.)
-    hostname: ""
-    # For more information regarding annotations, see
-    # https://kubernetes.io/docs/concepts/services-networking/service/#ssl-support-on-aws
-    annotations: {}
   # HTTP_PROXY: http://proxy:1234
   ## These named secrets (managed outside this chart) will be added to envFrom.
   envFromSecrets: []

--- a/values.yaml
+++ b/values.yaml
@@ -377,6 +377,14 @@ st2api:
   tolerations: []
   affinity: {}
   env: {}
+  service:
+    # type can be one of "ClusterIP", "NodePort", "LoadBalancer" or "ExternalName"
+    type: "ClusterIP"
+    # The hostname associated with st2api service (externalName, added to external DNS, etc.)
+    hostname: ""
+    # For more information regarding annotations, see
+    # https://kubernetes.io/docs/concepts/services-networking/service/#ssl-support-on-aws
+    annotations: {}
   # HTTP_PROXY: http://proxy:1234
   serviceAccount:
     attach: false
@@ -706,6 +714,14 @@ st2client:
     username = ${ST2_AUTH_USERNAME}
     password = ${ST2_AUTH_PASSWORD}
   env: {}
+  service:
+    # type can be one of "ClusterIP", "NodePort", "LoadBalancer" or "ExternalName"
+    type: "ClusterIP"
+    # The hostname associated with st2client service (externalName, added to external DNS, etc.)
+    hostname: ""
+    # For more information regarding annotations, see
+    # https://kubernetes.io/docs/concepts/services-networking/service/#ssl-support-on-aws
+    annotations: {}
   # HTTP_PROXY: http://proxy:1234
   ## These named secrets (managed outside this chart) will be added to envFrom.
   envFromSecrets: []


### PR DESCRIPTION
## Description

New feature to include possibility for external services in st2api and st2auth, setting default value for this services as `ClusterIP` and `hostname: ""`.

## Context

To enable remote servers remote communication with stackstorm, and not just within Kubernetes.