### PR TITLE
Update comment to show GC acts on action output by default.

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -769,7 +769,7 @@ st2client:
 
 # https://docs.stackstorm.com/reference/ha.html#st2garbagecollector
 # Optional service that cleans up old executions and other operations data based on setup configurations.
-# By default this process does nothing and needs to be setup in st2.conf to perform any work.
+# By default this process only cleans action output and needs to be setup in st2.conf to perform any other work.
 st2garbagecollector:
   # Having 1 st2garbagecollector unique replica is enough for periodic task like st2 history garbage collection
   replicas: 1


### PR DESCRIPTION
This is from the same boat as StackStorm/st2docs#1112 - We've been tweaking out GC configuration recently, and while doing so found that the action output GC is enabled by default. The comments & docs had led us to believe this wouldn't have been the case, so updating the comments here to explain this.