### PR TITLE
Added job to remove uninstalled packs from Mongo database

### DIFF
--- a/templates/configmaps_cleanup-packs-script.yaml
+++ b/templates/configmaps_cleanup-packs-script.yaml
@@ -1,0 +1,35 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-st2-cleanup-packs
+  labels: {{- include "stackstorm-ha.labels" (list $ "st2") | nindent 4 }}
+data:
+  st2-cleanup-packs.sh: |
+    #!/bin/bash
+
+    # Generate Token for StackStorm from Credentials
+    ST2_TOKEN=$(curl --fail -sk -X POST -u ${ST2_AUTH_USERNAME}:${ST2_AUTH_PASSWORD} ${ST2_AUTH_URL}/tokens | jq -r .token)
+
+    # Get the list of all packs from the StackStorm API
+    packs_in_db=$(curl --fail -sk -H "X-Auth-Token: $ST2_TOKEN" ${ST2_API_URL}/v1/packs | jq -r '.[].ref')
+
+    # Get the list of packs in the /opt/stackstorm/packs-shared directory
+    packs_in_dir=$(ls -1 /opt/stackstorm/packs-shared)
+
+    # Get the packs in the Database that aren't installed
+    packs_to_remove=()
+    for pack in $packs_in_db; do
+        if ! echo "$packs_in_dir" | grep -q "^$pack$"; then
+            packs_to_remove+=("$pack")
+        fi
+    done
+
+    # Purge old packs from DB
+    packs_to_remove_json_string=$(printf '%s\n' "${packs_to_remove[@]}" | jq -R . | jq -cs .)
+     if [ "$packs_to_remove_json_string" == '[""]' ]; then
+      echo "No packs to remove"
+    else
+      echo "Removing the folling packs: ${packs_to_remove_json_string}"
+      curl --fail -sk -X POST -H "X-Auth-Token: $ST2_TOKEN" -H 'Content-Type: application/json' -d "{\"packs\":${packs_to_remove_json_string}}"  ${ST2_API_URL}/v1/packs/uninstall
+    fi

--- a/templates/jobs.yaml
+++ b/templates/jobs.yaml
@@ -407,6 +407,7 @@ spec:
       initContainers:
       {{- include "stackstorm-ha.init-containers-wait-for-db" . | nindent 6 }}
       {{- include "stackstorm-ha.packs-initContainers" . | nindent 6 }}
+      {{- include "stackstorm-ha.cleanup-packs" . | nindent 6 }}
       {{- if $.Values.jobs.preRegisterContentCommand }}
       - name: st2-register-content-custom-init
         image: '{{ template "stackstorm-ha.imageRepository" . }}/st2actionrunner:{{ tpl (.Values.jobs.image.tag | default (.Values.st2actionrunner.image.tag | default .Values.image.tag)) . }}'
@@ -459,6 +460,10 @@ spec:
         {{- include "stackstorm-ha.st2-config-volume" . | nindent 8 }}
         {{- include "stackstorm-ha.packs-volumes" . | nindent 8 }}
         {{- include "stackstorm-ha.pack-configs-volume" . | nindent 8 }}
+        - name: st2-cleanup-packs
+          configMap:
+            name: {{ .Release.Name }}-st2-cleanup-packs
+            defaultMode: 0777
         {{- range $.Values.jobs.extra_volumes }}
         - name: {{ required "Each volume must have a 'name' in jobs.extra_volumes" .name }}
           {{- tpl (required "Each volume must have a 'volume' definition in jobs.extra_volumes" .volume | toYaml) $ | nindent 10 }}


### PR DESCRIPTION
Useful when changing the mounted pack image, that removes previously installed packs.

Normally the packs have been removed from disk, but are still registered in the Mongo database.

This runs a job as part of registering packs, to check for any packs no longer present on disk and removes them from the DB.